### PR TITLE
feat: page reshuffling — reorganise articles into sections

### DIFF
--- a/theMirror/blogs/next/index.html
+++ b/theMirror/blogs/next/index.html
@@ -79,6 +79,12 @@
             <li class="blog-item">
                 <a href="blogs/redesign_of_superhuman_workflows_now_that_ai_is_here.html" class="blog-link">Redesign of Superhuman Workflows Now That AI Is Here 0/&lt;</a>
             </li>
+            <li class="blog-item">
+                <a href="../../diary_pages/agent_universe.html" class="blog-link">The Map of the Agent Universe</a>
+            </li>
+            <li class="blog-item">
+                <a href="../../diary_pages/zoo_animals_and_context_windows.html" class="blog-link">Us Animals and Context Windows</a>
+            </li>
         </ul>
         <a href="../" class="back-link">← Back to Blogs</a>
     </div>

--- a/theMirror/data/index.html
+++ b/theMirror/data/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Research - The Mirror</title>
+    <title>Data - The Mirror</title>
     <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;1,400&family=Lora:ital,wght@0,400;1,400&display=swap" rel="stylesheet">
     <style>
         :root {
@@ -71,16 +71,10 @@
 </head>
 <body>
     <div class="container">
-        <h1>Research</h1>
+        <h1>Data</h1>
         <ul class="section-list">
             <li class="section-item">
-                <a href="seldon_framework.html" class="section-title">Hari Seldon's Framework — Mathematical Brief</a>
-            </li>
-            <li class="section-item">
-                <a href="../diary_pages/ai_neuroscience.html" class="section-title">AI Neuroscience</a>
-            </li>
-            <li class="section-item">
-                <a href="../diary_pages/learning_to_write.html" class="section-title">Learning to Write from People I Read</a>
+                <a href="../diary_pages/areas_of_ai.html" class="section-title">What Are All Different Areas of AI People Are Working On</a>
             </li>
         </ul>
         <a href="../" class="back-link">← Back to The Mirror</a>

--- a/theMirror/formalisation/seldon_framework.html
+++ b/theMirror/formalisation/seldon_framework.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hari Seldon's Framework — Mathematical Brief</title>
+<script>
+MathJax = {
+  tex: { inlineMath: [['$', '$'], ['\\(', '\\)']], displayMath: [['$$', '$$'], ['\\[', '\\]']] }
+};
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+<style>
+  body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    max-width: 820px;
+    margin: 40px auto;
+    padding: 0 24px;
+    line-height: 1.75;
+    color: #1a1a1a;
+    background: #fafafa;
+  }
+  h1 { font-size: 1.9em; margin-bottom: 0.2em; border-bottom: 2px solid #333; padding-bottom: 8px; }
+  h2 { font-size: 1.35em; margin-top: 2em; color: #2c2c2c; }
+  h3 { font-size: 1.1em; margin-top: 1.5em; color: #444; }
+  p { margin: 0.9em 0; }
+  table { border-collapse: collapse; margin: 1.2em 0; width: 100%; }
+  th, td { border: 1px solid #bbb; padding: 8px 14px; text-align: left; }
+  th { background: #e8e8e8; }
+  .note { background: #fff8e1; border-left: 4px solid #f5a623; padding: 12px 16px; margin: 1.4em 0; font-size: 0.95em; }
+  .summary-box { background: #eef6ff; border: 1px solid #a0c4e8; border-radius: 6px; padding: 16px 20px; margin: 2em 0; }
+  ul { padding-left: 1.4em; }
+  li { margin: 0.35em 0; }
+  code { background: #eee; padding: 2px 5px; border-radius: 3px; font-size: 0.92em; }
+</style>
+</head>
+<body>
+
+<h1>Hari Seldon's Framework: A Mathematical Brief</h1>
+<p><em>A formal translation of the 75-essay "Psychohistory" series on civilizational collapse, written in prose by HariSeldon on Substack, into the language of dynamical systems theory.</em></p>
+
+<div class="note">
+<strong>Authorship note:</strong> Hari Seldon never uses formal mathematical notation or dynamical-systems vocabulary in his essays. Terms like "coupled dynamical system," "bifurcation," "order parameter," "attractor," and "phase transition" are <em>my translations</em> of his qualitative, narrative model into mathematical language. His framework <em>behaves like</em> a coupled dynamical system — but he describes it entirely in prose, using concepts from complexity science, cybernetics, and social theory.
+</div>
+
+<h2>1. State Space: Four Capital Stocks</h2>
+
+<p>The system state at time $t$ is a vector of four capital stocks:</p>
+
+$$\mathbf{K}(t) = \big(K_e(t),\; K_c(t),\; K_s(t),\; K_\sigma(t)\big)$$
+
+<ul>
+  <li>$K_e$ — <strong>Economic capital</strong>: money, resources, infrastructure, work capacity</li>
+  <li>$K_c$ — <strong>Cultural capital</strong>: knowledge, paradigms, expertise, meaning-making frameworks (Bourdieu)</li>
+  <li>$K_s$ — <strong>Social capital</strong>: trust, networks, norms of reciprocity (Putnam)</li>
+  <li>$K_\sigma$ — <strong>Symbolic capital</strong>: legitimacy, credibility, institutional authority (Bourdieu)</li>
+</ul>
+
+<h3>Social Capital Decomposition</h3>
+<p>Social capital decomposes into three sub-types with qualitatively different roles:</p>
+
+$$K_s = K_b + K_{br} + K_l$$
+
+<ul>
+  <li>$K_b$ — <strong>Bonding capital</strong>: strong ties <em>within</em> groups (families, identity communities)</li>
+  <li>$K_{br}$ — <strong>Bridging capital</strong>: weak ties <em>across</em> groups (civic associations, cross-cutting networks)</li>
+  <li>$K_l$ — <strong>Linking capital</strong>: vertical ties connecting citizens to power structures</li>
+</ul>
+
+<h3>Complementarity Constraint (Liebig's Law)</h3>
+<p>Effective system capacity is governed by the <em>minimum</em> capital, not the sum or average:</p>
+
+$$C_{\text{eff}} \;\approx\; \min\!\big(K_e,\; K_c,\; K_s,\; K_\sigma\big)$$
+
+<p>Abundance in one capital <strong>cannot</strong> compensate for depletion in another. A wealthy society ($K_e$ high) with collapsed trust ($K_\sigma$ low) cannot coordinate — its effective capacity is bottlenecked at $K_\sigma$.</p>
+
+<h3>Convertibility (with losses)</h3>
+<p>Capitals are convertible through investment, but conversion is asymmetric and lossy — analogous to thermodynamic irreversibility:</p>
+
+$$K_i \xrightarrow{\text{invest}} K_j \quad \text{with} \quad \Delta K_j < \Delta K_i \quad \text{(efficiency loss)}$$
+
+
+<h2>2. The Debt Accelerant: Exponential Forcing</h2>
+
+<p>Debt $D(t)$ across all four domains (financial, ecological, social, cognitive) obeys compound growth:</p>
+
+$$D(t) = D_0\,(1 + r)^{\,t}$$
+
+<p>where $D_0$ is initial principal and $r$ is the effective interest/accumulation rate. Annual debt service cost is:</p>
+
+$$S(t) = r \cdot D(t) = r \cdot D_0\,(1+r)^{\,t}$$
+
+<p>Productive capacity $Y(t)$ grows at best linearly (or is bounded on a finite planet). The <strong>collapse condition</strong> is:</p>
+
+$$\boxed{S(t) > Y(t) \quad\Longrightarrow\quad \text{forced simplification (default / collapse)}}$$
+
+<p>Since $(1+r)^t$ grows exponentially while $Y(t)$ is bounded, this crossing is <strong>mathematically guaranteed</strong>. The only degrees of freedom are:</p>
+<ul>
+  <li><em>When</em> it happens (determined by $D_0$, $r$, and the growth rate of $Y$)</li>
+  <li><em>How</em> it resolves (orderly jubilee vs. chaotic default vs. hyperinflation)</li>
+</ul>
+
+<p>Seldon estimates current global debt at $D \approx \$300\text{T}$, $r \approx 4\text{–}5\%$, giving $S \approx \$12\text{–}15\text{T/yr}$, approaching threshold in the early-to-mid 2030s.</p>
+
+
+<h2>3. The HoPES Cycle: A Discrete Phase Map</h2>
+
+<p>When a problem exceeds system capacity (Ashby's Law of Requisite Variety: environmental variety &gt; internal variety), the system enters the <strong>Helix of Paradox in the Evolution of Systems (HoPES)</strong> — a 5-phase cycle:</p>
+
+$$\text{P}_1 \;\to\; \text{P}_2 \;\to\; \text{P}_3 \;\to\; \text{P}_4 \;\to\; \text{P}_5$$
+
+<table>
+  <tr><th>Phase</th><th>Name</th><th>Character</th></tr>
+  <tr><td>$\text{P}_1$</td><td>Polarization</td><td>Competing intuitive solutions emerge; schismogenesis (Bateson) amplifies division</td></tr>
+  <tr><td>$\text{P}_2$</td><td>Contradiction</td><td>Options crystallize into mutually exclusive either/or alternatives</td></tr>
+  <tr><td>$\text{P}_3$</td><td>Dilemma</td><td>Choice framed as sacrifice; fear-based decision-making dominates</td></tr>
+  <tr><td>$\text{P}_4$</td><td>Jeopardy</td><td>Implementation under existential framing; sunk cost lock-in</td></tr>
+  <tr><td>$\text{P}_5$</td><td>Confusion</td><td>Solution fails; problem re-emerges — the <strong>critical fork</strong></td></tr>
+</table>
+
+<h3>The Critical Bifurcation at Phase 5</h3>
+
+<p>At $\text{P}_5$, the system faces a binary branching:</p>
+
+<p><strong>Path A — Return</strong> (the default): $\;\text{P}_5 \to \text{P}_1$ at the same level, positions more entrenched. Capital dynamics per cycle $n$:</p>
+
+$$\mathbf{K}_{n+1} = \mathbf{K}_n - \Delta\mathbf{K}_{\text{loss}}(n)$$
+$$D_{n+1} = D_n + \Delta D(n)$$
+
+<p>Each Return <em>depletes</em> capital and <em>adds</em> debt. Cycle duration $\tau_n$ decreases monotonically — the system <strong>accelerates</strong>.</p>
+
+<p><strong>Path B — Reframe</strong> (rare): The system escapes to a higher-order attractor via both/and synthesis. Capital <em>regenerates</em>:</p>
+
+$$\mathbf{K}_{n+1} = \mathbf{K}_n + \Delta\mathbf{K}_{\text{gain}}(n)$$
+$$D_{n+1} < D_n$$
+
+
+<h2>4. The Bridging Capital Threshold: A Phase Transition</h2>
+
+<p>Define the <strong>bridging ratio</strong>:</p>
+
+$$\beta \;=\; \frac{K_{br}}{K_s} \;=\; \frac{K_{br}}{K_b + K_{br} + K_l}$$
+
+<p>This ratio functions as an <strong>order parameter</strong> governing the probability of Reframe vs. Return:</p>
+
+<table>
+  <tr><th>$\beta$</th><th>Regime</th></tr>
+  <tr><td>$\beta < 0.20$</td><td>Return is <strong>certain</strong> — echo chambers dominate, no cross-group synthesis possible</td></tr>
+  <tr><td>$0.20 < \beta < 0.30$</td><td>Return is <strong>near-certain</strong> — fragmentation too severe for collective reframing</td></tr>
+  <tr><td>$0.30 < \beta < 0.50$</td><td><strong>Contested</strong> — Reframe possible but not guaranteed</td></tr>
+  <tr><td>$\beta > 0.50$</td><td>Reframe <strong>possible</strong> — sufficient cross-cutting ties enable both/and integration</td></tr>
+</table>
+
+<p>Seldon estimates current U.S. bridging capital at $\beta \approx 0.15\text{–}0.20$, meaning Return is near-certain under current social architecture. This is effectively a <strong>phase transition</strong>: above $\beta \approx 0.30$ the system can self-correct; below it, the system is locked into capital-depleting Return spirals.</p>
+
+
+<h2>5. Three Coupled Layers</h2>
+
+<p>The system operates across three interacting layers, each with distinct dynamics but coupled through mutual feedback:</p>
+
+<h3>Layer 1: Structural (What Fails)</h3>
+<p>Eight simultaneous collapse stages forming a directed graph with reinforcing edges:</p>
+
+$$\text{S}_1 \rightleftharpoons \text{S}_2 \rightleftharpoons \text{S}_3 \rightleftharpoons \text{S}_4 \rightleftharpoons \text{S}_5 \rightleftharpoons \text{S}_6 \rightleftharpoons \text{S}_7 \rightleftharpoons \text{S}_8$$
+
+<table>
+  <tr><th>Stage</th><th>Dynamic</th><th>Primary Theory</th></tr>
+  <tr><td>$\text{S}_1$</td><td>Extractive institutions</td><td>Acemoglu & Robinson</td></tr>
+  <tr><td>$\text{S}_2$</td><td>Environmental overshoot</td><td>Diamond, Meadows</td></tr>
+  <tr><td>$\text{S}_3$</td><td>Complexity with diminishing returns</td><td>Tainter</td></tr>
+  <tr><td>$\text{S}_4$</td><td>Demographic-structural crisis / elite overproduction</td><td>Turchin, Scheidel</td></tr>
+  <tr><td>$\text{S}_5$</td><td>Military overextension</td><td>Kennedy</td></tr>
+  <tr><td>$\text{S}_6$</td><td>System fragility / tight coupling</td><td>Perrow, Taleb</td></tr>
+  <tr><td>$\text{S}_7$</td><td>Learning failures / ingenuity gaps</td><td>Senge, Homer-Dixon</td></tr>
+  <tr><td>$\text{S}_8$</td><td>Tipping points / cascading failure</td><td>Complex systems theory</td></tr>
+</table>
+
+<p>These are <strong>not sequential</strong>. Each $\text{S}_i$ amplifies every other $\text{S}_j$. Debt operates as universal accelerant across all eight.</p>
+
+<h3>Layer 2: Social Capital (Whether Response Is Possible)</h3>
+<p>The Putnam configuration $(K_b, K_{br}, K_l)$ determines whether collective response can occur. High $K_b$ with low $K_{br}$ produces <em>tribalism</em>, not coordination. The bridging ratio $\beta$ governs the Reframe/Return phase transition (see Section 4).</p>
+
+<h3>Layer 3: Metacognitive (Whether Frameworks Can Be Questioned)</h3>
+<p>Grounded in second-order cybernetics:</p>
+<ul>
+  <li><strong>First-order thinking</strong>: observe systems, optimize within existing paradigms</li>
+  <li><strong>Second-order thinking</strong>: observe the <em>observing systems themselves</em> — question whether the paradigm is the problem</li>
+</ul>
+<p>Elite capture of observation frameworks structurally prevents second-order capacity: those who benefit from existing paradigms control what counts as legitimate knowledge.</p>
+
+<h3>The Self-Reinforcing Trap (Layer Coupling)</h3>
+<p>The three layers form a positive feedback loop:</p>
+
+$$\text{Structural deterioration} \;\xrightarrow{\text{depletes}}\; K_{br} \;\xrightarrow{\text{prevents}}\; \text{collective response} \;\xrightarrow{\text{prevents}}\; \text{paradigm questioning} \;\xrightarrow{\text{prevents}}\; \text{structural reform}$$
+
+<p>This is the core trap of the model: each layer's failure reinforces the other two.</p>
+
+
+<h2>6. Perception–Reality Gap: Cynefin Mismatch</h2>
+
+<p>Each HoPES phase exhibits a systematic domain misperception (Snowden's Cynefin framework):</p>
+
+<table>
+  <tr><th>Phase</th><th>System Perceives</th><th>Reality Is</th><th>Error</th></tr>
+  <tr><td>$\text{P}_1$ — Polarization</td><td>Clear (obvious)</td><td>Chaotic (no patterns yet)</td><td>Premature certainty</td></tr>
+  <tr><td>$\text{P}_2$ — Contradiction</td><td>Complicated (analyzable)</td><td>Complex (emergent)</td><td>Analytical paralysis</td></tr>
+  <tr><td>$\text{P}_3$ — Dilemma</td><td>Complex (irreducible)</td><td>Complicated (analyzable if calm)</td><td>Unnecessary panic</td></tr>
+  <tr><td>$\text{P}_4$ — Jeopardy</td><td>Chaotic (crisis)</td><td>Clear (path visible to outsiders)</td><td>Desperate escalation</td></tr>
+  <tr><td>$\text{P}_5$ — Confusion</td><td>Confusion</td><td>Confusion</td><td><strong>Only accurate match</strong></td></tr>
+</table>
+
+<p>The inversion at Phases 3–4 is particularly destructive: when the system <em>could</em> analyze its way forward, it panics; when the path forward <em>is</em> clear, it perceives chaos.</p>
+
+
+<h2>7. Terminal Dynamics: Accelerating Returns</h2>
+
+<p>Under repeated Returns, the system exhibits predictable terminal behavior:</p>
+
+<ul>
+  <li>Cycle duration: $\tau_n \to 0$ &nbsp;(acceleration)</li>
+  <li>Capital stocks: $\mathbf{K}_n \to \mathbf{0}$ &nbsp;(exhaustion)</li>
+  <li>Debt: $D_n \to \infty$ &nbsp;(compound growth)</li>
+</ul>
+
+<p>The system enters <strong>pre-collapse stagnation</strong>: oscillating between Phases 2–3 without completing implementations because:</p>
+<ul>
+  <li>No $K_e$ left to execute solutions</li>
+  <li>No $K_s$ left to coordinate</li>
+  <li>$K_c$ is trapped in dead paradigms</li>
+  <li>No $K_\sigma$ left to lead</li>
+</ul>
+
+<p>Collapse is then a <strong>discontinuous phase transition</strong>: long periods of apparently stable dysfunction, followed by rapid catastrophic simplification when the last buffer is consumed.</p>
+
+<p>The Roman third-century crisis illustrates: ~50 emperors in 50 years, each cycle shorter and more dysfunctional, until Diocletian's radical restructuring (a partial Reframe) in 284 CE.</p>
+
+
+<h2>8. Summary Equation (Metaphorical)</h2>
+
+<p>The entire model compressed into one expression:</p>
+
+$$\boxed{\frac{d\mathbf{K}}{dt} \;=\; \underbrace{-f(\text{8 stages})}_{\text{structural drain}} \;\underbrace{- \;g\!\big(D(t)\big)}_{\text{debt acceleration}} \;\underbrace{- \;h(\text{Returns})}_{\text{cycle depletion}} \;+\; \underbrace{\phi(\beta)\cdot R(\text{Reframe})}_{\text{regeneration (if } \beta > 0.30 \text{)}}}$$
+
+<p>When $\beta < 0.30$, $\;\phi(\beta) \approx 0$ — the Reframe term vanishes. The system is left with <strong>only capital-depleting terms</strong>. Collapse becomes a mathematical inevitability.</p>
+
+
+<div class="summary-box">
+<h2 style="margin-top:0;">One-Sentence Summary</h2>
+<p>It is a model of civilizational dynamics as a <strong>dissipative system on four coupled capital stocks</strong>, driven through a recurring <strong>5-phase decision cycle</strong> whose outcome (regenerative Reframe vs. depleting Return) is governed by a <strong>bridging-capital order parameter</strong> $\beta$, with <strong>compound debt as exponential forcing</strong> guaranteeing eventual collapse unless the system escapes to a higher-order attractor through second-order metacognition — which the system's own structure systematically prevents.</p>
+</div>
+
+<h2>Appendix: Seldon's Probability Estimates (2025–2045)</h2>
+
+<table>
+  <tr><th>Trajectory</th><th>Probability</th><th>Character</th></tr>
+  <tr><td>Turbulent Transition</td><td>50–60%</td><td>Significant suffering, civilization survives but severely degraded, recovery takes centuries</td></tr>
+  <tr><td>Convergent Collapse</td><td>20–30%</td><td>Cascading failures, irreversible tipping points, potential regional civilizational collapse</td></tr>
+  <tr><td>Managed Simplification</td><td>10–20%</td><td>Proactive adaptation through jubilee, bridging capital rebuild, second-order institutions<br>(increasable to 30–40% with comprehensive action during 2025–2035)</td></tr>
+</table>
+
+<p>The decisive variable: whether $\beta$ can be rebuilt from ~0.15–0.20 to above 0.30 by the 2030–2035 crisis decade.</p>
+
+</body>
+</html>

--- a/theMirror/index.html
+++ b/theMirror/index.html
@@ -237,7 +237,7 @@
 
                 <ul class="social-links" style="margin-top: 0.5rem; opacity: 1;">
                     <li><a href="formalisation/" style="opacity: 0.8; font-weight: 600;">Research</a></li>
-                    <li><a href="coming-soon.html" style="opacity: 0.8; font-weight: 600;">Data</a></li>
+                    <li><a href="data/" style="opacity: 0.8; font-weight: 600;">Data</a></li>
                     <li><a href="blogs/" style="opacity: 0.8; font-weight: 600;">Blogs</a></li>
                     <li><a href="coming-soon.html" style="opacity: 0.8; font-weight: 600;">Me</a></li>
                 </ul>
@@ -257,26 +257,11 @@
             <a href="diary_pages/are_agents_turning_machine.html" style="text-decoration: none; display: block;">
                 <div class="journal-line">are agents turning machine?</div>
             </a>
-            <a href="diary_pages/areas_of_ai.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">what are all different areas of ai people are working on</div>
-            </a>
-            <a href="diary_pages/ai_neuroscience.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">AI neuroscience</div>
-            </a>
             <a href="diary_pages/my_thinking_assistant_design.html" style="text-decoration: none; display: block;">
                 <div class="journal-line">my thinking assistant's design</div>
             </a>
-            <a href="blogs/next/blogs/redesign_of_superhuman_workflows_now_that_ai_is_here.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">redesign of superhuman workflows now that ai is here 0/&lt;</div>
-            </a>
-            <a href="diary_pages/agent_universe.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">the map of the agent universe</div>
-            </a>
             <a href="diary_pages/zoo_animals_and_context_windows.html" style="text-decoration: none; display: block;">
                 <div class="journal-line">us animals and context windows</div>
-            </a>
-            <a href="diary_pages/learning_to_write.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">learning to write from people i read</div>
             </a>
             <div class="journal-line"></div>
             <div class="journal-line"></div>


### PR DESCRIPTION
## Summary
- Moves articles from home page journal into their correct sections (research, data, blogs)
- Creates new `data/index.html` listing page and `formalisation/seldon_framework.html` (original research article)
- Replaces `formalisation/index.html` with a research listing page; updates Data nav link from `coming-soon.html` to `data/`
- No content changes to any articles

## Test plan
- [ ] Home page shows only: "are agents turning machine?", "my thinking assistant's design", "us animals and context windows"
- [ ] Research page (`/formalisation/`) lists Seldon Framework, AI Neuroscience, Learning to Write
- [ ] Seldon Framework article still accessible at `/formalisation/seldon_framework.html`
- [ ] Data page (`/data/`) lists "What Are All Different Areas of AI People Are Working On"
- [ ] Blogs/next page lists the two new entries (agent universe, us animals and context windows)
- [ ] Data nav link on home page points to `data/` not `coming-soon.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)