### PR TITLE
add kindle reads page with gwern essay annotations

### DIFF
--- a/theMirror/diary_pages/kindle_reads.html
+++ b/theMirror/diary_pages/kindle_reads.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kindle Reads - The Mirror</title>
+    <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400..700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --paper: #F4F0EB;
+            --ink: #2C2C2C;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: var(--paper);
+            color: var(--ink);
+            min-height: 100vh;
+        }
+        .journal-container {
+            width: 100%;
+            padding: 40px;
+            box-sizing: border-box;
+            position: relative;
+        }
+        .journal-container::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 50%;
+            width: 1px;
+            background: rgba(255, 0, 0, 0.15);
+            z-index: 0;
+        }
+        .journal-line {
+            border-bottom: 1px solid rgba(0,0,0,0.1);
+            min-height: 3.5rem;
+            display: flex;
+            align-items: flex-end;
+            padding-bottom: 0.5rem;
+            padding-left: 2rem;
+            font-family: 'Dancing Script', cursive;
+            font-size: 1.8rem;
+            font-weight: 500;
+            color: #2a2a2a;
+            line-height: 1.55;
+            white-space: pre-wrap;
+        }
+        .back-link {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            font-family: serif;
+            text-decoration: none;
+            color: var(--ink);
+            opacity: 0.5;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            background: var(--paper);
+            padding: 5px;
+        }
+        .back-link:hover {
+            opacity: 1;
+        }
+        @media (max-width: 600px) {
+            .journal-line {
+                font-size: 1.4rem;
+                padding-left: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="journal-container">
+        <div class="journal-line" style="color: #555; border-bottom: 2px solid rgba(0,0,0,0.1);">kindle reads: why tool ais want to be agent ais</div>
+        <div class="journal-line" style="font-size: 1.1rem; color: #888;">essay: <a href="https://gwern.net/tool-ai" target="_blank" style="color: #888; text-decoration: underline; font-family: 'Dancing Script', cursive;">gwern.net/tool-ai</a></div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">(first-pass annotations — section by section)</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">Epigraph (Wiener, 1960)</div>
+        <div class="journal-line">opens with "We wish a slave to be intelligent...complete subservience and complete intelligence do not go together."</div>
+        <div class="journal-line">hands you the whole argument before the essay starts.</div>
+        <div class="journal-line">technique: thesis-as-epigraph. the quote does more work than most introductions.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">Setup / abstract</div>
+        <div class="journal-line">states the problem directly — Tool AIs are proposed as safer, but this safety will not hold.</div>
+        <div class="journal-line">no warming up. the stakes are on the table by paragraph one.</div>
+        <div class="journal-line">technique: start with the adversarial frame, not the background.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">Economic section</div>
+        <div class="journal-line">Amdahl's Law — humans as the bottleneck. as AI gets better, keeping humans in the loop becomes the thing slowing you down.</div>
+        <div class="journal-line">then: YouTube, chess, drone warfare as examples.</div>
+        <div class="journal-line">makes the argument feel inevitable rather than speculative. you're not thinking "maybe" — you're thinking "oh, this is already happening."</div>
+        <div class="journal-line">technique: ground abstract economic logic in real, escalating examples. the escalation matters: YouTube is mundane, drone warfare is alarming.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">Intelligence section</div>
+        <div class="journal-line">now argues agents are smarter by nature, not just cheaper.</div>
+        <div class="journal-line">key move: agents are a superset of tools (an agent can choose to act like a tool when tools are best).</div>
+        <div class="journal-line">closes the first escape hatch. good-enough isn't achievable without building the thing you were trying to avoid.</div>
+        <div class="journal-line">technique: superset argument — use set theory logic to make the conclusion feel definitionally true.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">Actions at every layer</div>
+        <div class="journal-line">systematically shows that agency isn't one thing you add on top — it shows up at every layer.</div>
+        <div class="journal-line">at the third layer you feel you can't escape. this isn't one argument; it's five independent arguments that each hold.</div>
+        <div class="journal-line">technique: taxonomic exhaustion — don't make the case once, make it at every level of abstraction so there's nowhere to hide.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">No conclusion</div>
+        <div class="journal-line">essay just ends with "See Also" links. no wrap-up, no restatement, no call to action.</div>
+        <div class="journal-line">signals confidence. he doesn't feel the need to summarize because the argument is settled.</div>
+        <div class="journal-line">technique: ending without a conclusion as a power move.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">(second-pass additions — things understood better after seeing the whole essay)</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">the epigraph already contains the full argument. the entire essay is just proving Wiener's 1960 observation.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">"concede, then overwhelm" is the backbone. every section acknowledges the safety concern is real, then shows it doesn't matter.</div>
+        <div class="journal-line">the concession happens fast; the overwhelm is slow and thorough.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">the five-layer structure is an escape-proof cage. you'd have to defeat all five arguments independently.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">he names his own rhetorical moves. "i'm using X to mean Y." this builds credibility and preempts attacks.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">the examples escalate in moral weight on purpose. YouTube → chess → drone warfare.</div>
+        <div class="journal-line">by the time he gets to drone warfare, the "inevitability" framing has picked up moral dread. you feel the stakes, not just the logic.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">no conclusion = "i don't need to convince you of anything more." it works because by that point the reader has been walked through five independent proofs.</div>
+        <div class="journal-line"></div>
+
+        <div class="journal-line" style="font-weight: 700;">(skills to steal)</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">1. put the thesis in the epigraph. find a quote that says your whole argument in one sentence.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">2. start with the adversarial frame. open with the thing you're arguing against, stated as charitably as possible. then dismantle it.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">3. escalate examples in moral weight. start mundane (YouTube), move toward alarming (drone warfare).</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">4. use the superset argument. if your position logically includes the alternative as a special case, the alternative can never beat you.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">5. taxonomic exhaustion. don't make one argument. make five sub-arguments that each hold independently.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">6. concede fast, bury slow. acknowledge the counterargument in one sentence. then spend three paragraphs making it irrelevant.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">7. name your own rhetorical moves. "i'm using X to mean Y." builds credibility, preempts attacks.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">8. double-flank. after making the positive case, make the negative case against the alternative.</div>
+        <div class="journal-line"></div>
+        <div class="journal-line">9. end without a conclusion. if you've built the argument well enough, you don't need to restate it. just stop.</div>
+        <div class="journal-line"></div>
+
+        <script>
+            for(let i=0; i<10; i++) {
+                document.write('<div class="journal-line"></div>');
+            }
+        </script>
+    </div>
+    <a href="../" class="back-link">← Back to The Mirror</a>
+</body>
+</html>

--- a/theMirror/index.html
+++ b/theMirror/index.html
@@ -240,6 +240,7 @@
                     <li><a href="coming-soon.html" style="opacity: 0.8; font-weight: 600;">Data</a></li>
                     <li><a href="blogs/" style="opacity: 0.8; font-weight: 600;">Blogs</a></li>
                     <li><a href="coming-soon.html" style="opacity: 0.8; font-weight: 600;">Me</a></li>
+                    <li><a href="diary_pages/kindle_reads.html" style="opacity: 0.8; font-weight: 600;">Kindle Reads</a></li>
                 </ul>
             </div>
             


### PR DESCRIPTION
## Summary
- New page `diary_pages/kindle_reads.html` styled like `learning_to_write.html` with journal-line layout
- Annotates Gwern's essay [Why Tool AIs Want to Be Agent AIs](https://gwern.net/tool-ai) in three passes: first-pass, second-pass, and skills to steal
- Added "Kindle Reads" link to homepage nav

## Test plan
- [ ] Visit `diary_pages/kindle_reads.html` — parchment background, Dancing Script font, red vertical line
- [ ] Back link returns to homepage
- [ ] Homepage nav shows "Kindle Reads" link pointing to the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)