### PR TITLE
Remove agent articles from home page listing

### DIFF
--- a/theMirror/index.html
+++ b/theMirror/index.html
@@ -255,12 +255,6 @@
 
         <!-- Journal Journal Section -->
         <div class="journal-container">
-            <a href="formalisation/are_agents_turning_machine.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">are agents turning machine?</div>
-            </a>
-            <a href="blogs/next/blogs/my_thinking_assistant_design.html" style="text-decoration: none; display: block;">
-                <div class="journal-line">my thinking assistant's design</div>
-            </a>
             <a href="diary_pages/zoo_animals_and_context_windows.html" style="text-decoration: none; display: block;">
                 <div class="journal-line">us animals and context windows</div>
             </a>


### PR DESCRIPTION
## Summary
- Removes "are agents turning machine?" and "my thinking assistant's design" from the journal section on the home page
- Articles are NOT deleted — they remain accessible via their existing URLs and are still linked from other pages

## Test plan
- [ ] Verify home page no longer lists the two removed articles
- [ ] Verify the article pages themselves still load at their original URLs
- [ ] Verify other journal entries (e.g. "us animals and context windows") still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)