### PR TITLE
Replace client-side Substack fetch with static JSON snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ public/
 
 ## Manual updates that are easy to forget
 
+- **`src/data/substack.json`** — cached snapshot of the Substack RSS feed shown on the home page. Substack 403s GitHub Actions IPs, so we cannot fetch at build time. Refresh by running `npm run sync-substack` locally and committing the regenerated file. If the file is missing or empty, the home page silently hides the section.
 - **`public/llms.txt`** — static llmstxt.org-format index of the site's posts. **Must be updated by hand** when posts are added, removed, renamed, or get a new summary. Currently lists every published post. Could be auto-generated from content collections at build time as a follow-up; not done yet.
 - **`public/robots.txt`** — allow-all + sitemap pointer. Rarely needs updating, but if you ever add paths that should be hidden, edit here.
 - **`featured_slugs` and `unfinished_slugs`** in `site.config.ts` — silently drop slugs that don't match a published post (intentional, keeps the home resilient). If a featured post seems missing, check the slug + that the post is `draft: false`.
@@ -85,9 +86,10 @@ public/
 
 ```bash
 npm install
-npm run dev      # http://localhost:4321
-npm run build    # writes to dist/
-npm run preview  # serves the production build locally
+npm run dev             # http://localhost:4321
+npm run build           # writes to dist/
+npm run preview         # serves the production build locally
+npm run sync-substack   # refresh src/data/substack.json from the Substack RSS feed (run locally, then commit)
 ```
 
 ## Verification before claiming "done"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Mirror collects long-form writing on AI architecture (agents, context window
 
 | Section | URL | What lives there |
 |---|---|---|
-| Home | `/` | Hero, embedded video, social row, manually pinned featured posts, latest Substack posts (pulled from RSS at build time) |
+| Home | `/` | Hero, embedded video, social row, manually pinned featured posts, latest Substack posts (cached snapshot — refresh with `npm run sync-substack`) |
 | Blog | `/blog/` | Long-form essays |
 | Research | `/research/` | Pieces grounded in math, papers, proof |
 | Data | `/data/` | Numbers, charts, the maps behind them |
@@ -39,10 +39,11 @@ src/
 │   ├── fantasy/*.md
 │   └── tools/*.mdx
 ├── site.config.ts      # featured posts, unfinished posts, social links
+├── data/
+│   └── substack.json   # cached Substack feed snapshot (regen via npm run sync-substack)
 ├── lib/
 │   ├── clusters.ts     # cluster groupings shown on each index page
-│   ├── collections.ts  # helper for fetching published entries
-│   └── substack.ts     # fetches + parses Substack RSS feed at build time
+│   └── collections.ts  # helper for fetching published entries
 ├── components/         # Section, PostMeta, BackLink, UnfinishedBar, etc.
 ├── layouts/            # BaseLayout, PageLayout, PostLayout, IndexLayout, ComingSoonLayout
 ├── pages/              # routes (one file per URL; [slug].astro for dynamic)
@@ -75,3 +76,4 @@ Pushed automatically by GitHub Actions on every push to `main` (`.github/workflo
 - **Pin a post on the home page** — add `'<collection>/<slug>'` to `featured_slugs` in `src/site.config.ts`. Up to 8 fit in the journal block.
 - **Mark a post as unfinished** — add `'<collection>/<slug>'` to `unfinished_slugs` in `src/site.config.ts`. A maroon warning bar appears at the top of the post.
 - **Group posts on an index page** — edit `src/lib/clusters.ts`. Posts not in any cluster auto-fall into a synthetic `rest` cluster.
+- **Refresh the Substack list on the home page** — run `npm run sync-substack` locally (Substack blocks GitHub Actions' IPs, so this can't be auto-fetched at build time) and commit the updated `src/data/substack.json`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "sync-substack": "node scripts/sync-substack.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/scripts/sync-substack.mjs
+++ b/scripts/sync-substack.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Fetches the Substack RSS feed and writes a static JSON snapshot at
+// src/data/substack.json. Run locally (`npm run sync-substack`) whenever
+// you want the home page to pick up new Substack posts; commit the file.
+// Substack 403s GitHub Actions IPs, so we cannot fetch at build time.
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FEED_URL = 'https://janhavidadhania.substack.com/feed';
+const LIMIT = 20;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, '../src/data/substack.json');
+
+function pick(block, tag) {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i');
+  const m = block.match(re);
+  if (!m) return '';
+  let v = m[1].trim();
+  const cdata = v.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
+  if (cdata) v = cdata[1].trim();
+  return v
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+const res = await fetch(FEED_URL, {
+  headers: {
+    'User-Agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    Accept: 'application/rss+xml, application/xml;q=0.9, */*;q=0.8',
+  },
+});
+if (!res.ok) {
+  console.error(`Substack feed fetch failed: ${res.status} ${res.statusText}`);
+  process.exit(1);
+}
+
+const xml = await res.text();
+const blocks = xml.match(/<item>[\s\S]*?<\/item>/g) ?? [];
+const posts = blocks
+  .map((b) => ({
+    title: pick(b, 'title'),
+    link: pick(b, 'link'),
+    pubDate: new Date(pick(b, 'pubDate')).toISOString(),
+    description: pick(b, 'description'),
+  }))
+  .filter((p) => p.title && p.link)
+  .sort((a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
+  .slice(0, LIMIT);
+
+await mkdir(dirname(OUT), { recursive: true });
+await writeFile(OUT, JSON.stringify({ fetchedAt: new Date().toISOString(), posts }, null, 2) + '\n');
+console.log(`Wrote ${posts.length} posts to ${OUT}`);

--- a/src/data/substack.json
+++ b/src/data/substack.json
@@ -1,0 +1,65 @@
+{
+  "fetchedAt": "2026-05-19T12:14:44.267Z",
+  "posts": [
+    {
+      "title": "write your autobiography",
+      "link": "https://janhavidadhania.substack.com/p/write-your-autobiography",
+      "pubDate": "2026-04-17T21:56:44.000Z",
+      "description": "thought on storing all of our thoughts"
+    },
+    {
+      "title": "Hard drive, LLM and you",
+      "link": "https://janhavidadhania.substack.com/p/hard-drive-llm-and-you",
+      "pubDate": "2026-04-17T21:49:05.000Z",
+      "description": "memex; memory extended, a system for interacting with LLMs and the storage"
+    },
+    {
+      "title": "Production of Ideas",
+      "link": "https://janhavidadhania.substack.com/p/production-of-ideas",
+      "pubDate": "2025-11-15T09:56:25.000Z",
+      "description": "anxiety of incomplete knowledge"
+    },
+    {
+      "title": "What is Consciousness?",
+      "link": "https://janhavidadhania.substack.com/p/what-is-consciousness",
+      "pubDate": "2025-09-23T12:00:32.000Z",
+      "description": "and free will."
+    },
+    {
+      "title": "What does it mean to be human in the age of AI?",
+      "link": "https://janhavidadhania.substack.com/p/what-does-it-mean-to-be-human-in",
+      "pubDate": "2025-09-04T07:10:45.000Z",
+      "description": "AI is doing everything, what's the point of you existing then?"
+    },
+    {
+      "title": "How long will it take for machines to take over?",
+      "link": "https://janhavidadhania.substack.com/p/how-long-will-it-take-for-machines",
+      "pubDate": "2025-09-02T19:46:39.000Z",
+      "description": "Landscape of Human Competence"
+    },
+    {
+      "title": "what does it mean to be AI?",
+      "link": "https://janhavidadhania.substack.com/p/what-does-it-mean-to-be-ai",
+      "pubDate": "2025-08-24T15:34:02.000Z",
+      "description": "in the world of humans..."
+    },
+    {
+      "title": "AI, a Software Organism & IGUS",
+      "link": "https://janhavidadhania.substack.com/p/ai-a-software-organism-and-igus",
+      "pubDate": "2025-07-20T18:23:18.000Z",
+      "description": "How does AI as IGUS compare with biological complex adaptive organisms"
+    },
+    {
+      "title": "Role of right Narratives in Driving society",
+      "link": "https://janhavidadhania.substack.com/p/role-of-right-narratives-in-driving",
+      "pubDate": "2025-05-13T17:50:35.000Z",
+      "description": "why Americans always want to save the world, uncertainties in complex systems"
+    },
+    {
+      "title": "Does God Play Dice to decide your future?",
+      "link": "https://janhavidadhania.substack.com/p/does-god-play-dice-to-decide-your",
+      "pubDate": "2025-02-08T19:18:17.000Z",
+      "description": "yes."
+    }
+  ]
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 import Hero from '@/components/Hero.astro';
 import { site } from '@/site.config';
 import { getCollection, type CollectionEntry } from 'astro:content';
+import substackData from '@/data/substack.json';
 
 type FeaturedCollection = 'blog' | 'research' | 'data' | 'fantasy' | 'tools';
 type AnyEntry = CollectionEntry<FeaturedCollection>;
@@ -43,6 +44,13 @@ const journalLines: JournalLine[] = wanted
     label: entry.collection,
   }));
 
+const substackPosts = (substackData.posts ?? []).map((p) => ({
+  ...p,
+  pubDate: new Date(p.pubDate),
+}));
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  month: 'short', day: 'numeric', year: 'numeric',
+});
 ---
 <BaseLayout>
   <main class="container">
@@ -59,79 +67,28 @@ const journalLines: JournalLine[] = wanted
       ))}
     </section>
 
-    <section class="substack" id="substack-section" hidden>
-      <h2 class="substack-heading">from substack</h2>
-      <ul class="substack-list" id="substack-list"></ul>
-    </section>
+    {substackPosts.length > 0 && (
+      <section class="substack">
+        <h2 class="substack-heading">from substack</h2>
+        <ul class="substack-list">
+          {substackPosts.map((post) => (
+            <li class="substack-item">
+              <a
+                class="substack-link"
+                href={post.link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="substack-title">{post.title}</span>
+                <span class="substack-date">{dateFmt.format(post.pubDate)}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
   </main>
 </BaseLayout>
-
-<script is:inline>
-  (async () => {
-    const FEED = 'https://janhavidadhania.substack.com/feed';
-    const PROXIES = [
-      (u) => 'https://api.allorigins.win/raw?url=' + encodeURIComponent(u),
-      (u) => 'https://corsproxy.io/?' + encodeURIComponent(u),
-    ];
-
-    async function loadXml() {
-      for (const build of PROXIES) {
-        try {
-          const res = await fetch(build(FEED), { cache: 'no-store' });
-          if (!res.ok) continue;
-          const text = await res.text();
-          if (text && text.includes('<item')) return text;
-        } catch {}
-      }
-      return null;
-    }
-
-    const xml = await loadXml();
-    if (!xml) return;
-
-    const doc = new DOMParser().parseFromString(xml, 'text/xml');
-    const items = Array.from(doc.querySelectorAll('item')).slice(0, 20);
-    if (!items.length) return;
-
-    const list = document.getElementById('substack-list');
-    const section = document.getElementById('substack-section');
-    if (!list || !section) return;
-
-    const dateFmt = new Intl.DateTimeFormat('en-US', {
-      month: 'short', day: 'numeric', year: 'numeric',
-    });
-
-    for (const item of items) {
-      const title = item.querySelector('title')?.textContent?.trim() ?? '';
-      const link = item.querySelector('link')?.textContent?.trim() ?? '';
-      const pubDate = item.querySelector('pubDate')?.textContent?.trim() ?? '';
-      if (!title || !link) continue;
-
-      const li = document.createElement('li');
-      li.className = 'substack-item';
-      const a = document.createElement('a');
-      a.className = 'substack-link';
-      a.href = link;
-      a.target = '_blank';
-      a.rel = 'noopener noreferrer';
-      const titleSpan = document.createElement('span');
-      titleSpan.className = 'substack-title';
-      titleSpan.textContent = title;
-      const dateSpan = document.createElement('span');
-      dateSpan.className = 'substack-date';
-      if (pubDate) {
-        const d = new Date(pubDate);
-        if (!isNaN(d.getTime())) dateSpan.textContent = dateFmt.format(d);
-      }
-      a.appendChild(titleSpan);
-      a.appendChild(dateSpan);
-      li.appendChild(a);
-      list.appendChild(li);
-    }
-
-    section.hidden = false;
-  })();
-</script>
 
 <style>
   .container {
@@ -201,10 +158,10 @@ const journalLines: JournalLine[] = wanted
     padding: 0;
     margin: 0;
   }
-  :global(.substack-item) {
+  .substack-item {
     border-bottom: 1px solid var(--rule);
   }
-  :global(.substack-link) {
+  .substack-link {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
@@ -213,17 +170,17 @@ const journalLines: JournalLine[] = wanted
     text-decoration: none;
     color: inherit;
   }
-  :global(.substack-link:hover .substack-title) {
+  .substack-link:hover .substack-title {
     text-decoration: underline;
   }
-  :global(.substack-title) {
+  .substack-title {
     font-family: var(--font-script);
     font-style: italic;
     font-size: 1.4rem;
     color: #2a2a2a;
     letter-spacing: 0.01em;
   }
-  :global(.substack-date) {
+  .substack-date {
     font-size: 0.85rem;
     color: var(--ink-faded);
     white-space: nowrap;


### PR DESCRIPTION
The CORS-proxy approach (allorigins.win) introduced unacceptable page load latency. Switch to a cached snapshot at src/data/substack.json, generated by a new local script `npm run sync-substack`. The home page reads the JSON at build time and renders the section server-side with zero runtime cost. Document the manual refresh workflow in CLAUDE.md and README.