### PR TITLE
me page: add reading & writings section

### DIFF
--- a/src/pages/me.astro
+++ b/src/pages/me.astro
@@ -19,6 +19,17 @@ import PageLayout from '@/layouts/PageLayout.astro';
       <a href="mailto:janhavivdadhania@gmail.com">janhavivdadhania@gmail.com</a>
       if you too share interest in complex systems and AI.
     </p>
+    <section class="me-section">
+      <h2 class="me-section-title">reading &amp; writings</h2>
+      <p class="me-bio">
+        I never read without notebookLM now. I never write on substack that is
+        meant to be read by notebookLM. Example of a text which is not meant to
+        be read via notebookLM,
+        <a href="https://webhomes.maths.ed.ac.uk/~v1ranick/papers/wigner.pdf" target="_blank" rel="noopener">https://webhomes.maths.ed.ac.uk/~v1ranick/papers/wigner.pdf</a>
+        and example of text that is meant to be read via notebookLM,
+        <a href="/blog/if-plato-had-notebooklm/">https://concavemirror.to/blog/if-plato-had-notebooklm/</a>
+      </p>
+    </section>
   </article>
 </PageLayout>
 
@@ -52,4 +63,19 @@ import PageLayout from '@/layouts/PageLayout.astro';
     text-underline-offset: 3px;
   }
   .me-bio a:hover { opacity: 0.65; }
+  .me-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    width: 100%;
+  }
+  .me-section-title {
+    font-family: var(--font-serif);
+    font-size: 1.25rem;
+    font-weight: 500;
+    font-style: italic;
+    color: var(--ink);
+    margin: 0;
+    letter-spacing: 0.01em;
+  }
 </style>


### PR DESCRIPTION
## Summary
Adds a new "reading & writings" section below the bio paragraph on /me, with prose about notebookLM and two example links (wigner.pdf external, if-plato-had-notebooklm internal). Styles reuse existing tokens and the existing link pattern.

## Test plan
- [ ] `npm run build` succeeds
- [ ] /me renders the new section below the bio with the photo + bio untouched
- [ ] Wigner PDF link opens in a new tab
- [ ] if-plato-had-notebookLM link navigates to the post on this site
- [ ] Section title styling reads as understated/journal-y (review wording too — copy is verbatim from spec, not edited)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>