### PR TITLE
fantasy: add "my process of writing long novel"

### DIFF
--- a/src/content/fantasy/my-process-of-writing-long-novel.md
+++ b/src/content/fantasy/my-process-of-writing-long-novel.md
@@ -1,0 +1,21 @@
+---
+title: "my process of writing long novel"
+date: 2026-05-23
+tags: []
+summary: "On being a discovery writer — starting from an idea, growing a cluster, leaving 80% empty for ideas to arrive on their own."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 8
+  evidence_strength: 3
+---
+
+discovery writer.
+
+I start with the idea or opinion that interests me. For example, godel's theorem. And then imagine a story to best illustrate it and understand it better.
+
+this gets linked with bunch of smaller ideas and their plots and becomes a cluster.
+
+i have a mindland and matterland formed, and also godels' theorem that is going to create a plot that they two together are not consistant (which they had been looking for) but that is exectly hy they are complete. They can together add meaning.
+
+and I add sotry elements like grey people that links these two lands. 80% of the story is still empty, ideas will come to me naturally. I do not force. they never come that way.


### PR DESCRIPTION
## Summary
- New fantasy page on Janhavi's discovery-writer process — starting from an idea (Gödel's theorem), growing a cluster, leaving 80% of the story empty for ideas to arrive naturally.
- Route: \`/fantasy/my-process-of-writing-long-novel/\`
- Prose preserved **verbatim** per janhavi's earlier rule — typos and lowercase opening left as written. Edit in this PR if you want them cleaned.

## Test plan
- [x] \`npm run build\` succeeds (23 pages built)
- [x] Route emitted in \`dist/fantasy/my-process-of-writing-long-novel/index.html\`
- [ ] Verify page renders correctly on the deployed preview
- [ ] Verify it shows up in the fantasy index/listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)