### PR TITLE
mirror: tidy areas-of-ai intro, drop post meta labels, update /me rea…

### DIFF
--- a/src/content/data/areas-of-ai.mdx
+++ b/src/content/data/areas-of-ai.mdx
@@ -10,12 +10,6 @@ meta:
   evidence_strength: 5
 ---
 
-everyone is talking about AI. Elon Musk, our governments, Pope Leo, your neighbour.
-
-that alone tells you how big this change is — and it is happening right now.
-
-— listing and tracking down the sub-areas —
-
 <Section color="maroon" label="0. investing in ai">
 the money that makes everything else possible. shapes what gets built and what doesn't.
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from './BaseLayout.astro';
-import PostMeta from '@/components/PostMeta.astro';
 import BackLink from '@/components/BackLink.astro';
 import UnfinishedBar from '@/components/UnfinishedBar.astro';
 import { site } from '@/site.config';
@@ -19,9 +18,10 @@ interface Props {
   };
 }
 
-// `tags` is intentionally accepted in the props (schema requires it) but not
-// rendered on the post page — it's used for indexes and previews only.
-const { slug, title, summary, meta } = Astro.props;
+// `tags` and `meta` are accepted in the props (schema requires them) but not
+// rendered on the post page right now — the meta block was removed per janhavi
+// (2026-05-24); keeping the fields in frontmatter so the area can be restored.
+const { slug, title, summary } = Astro.props;
 
 const isUnfinished = site.unfinished_slugs.includes(slug);
 
@@ -39,9 +39,7 @@ const rightMargin = 50 + Math.floor(Math.random() * 100) + 1;
     {isUnfinished && <UnfinishedBar />}
     <header class="post-header">
       <h1 class="post-title">{title}</h1>
-      <div class="post-meta-wrap">
-        <PostMeta meta={meta} />
-      </div>
+      <div class="post-meta-wrap"></div>
     </header>
 
     <div class="post-body">

--- a/src/pages/me.astro
+++ b/src/pages/me.astro
@@ -22,12 +22,12 @@ import PageLayout from '@/layouts/PageLayout.astro';
     <section class="me-section">
       <h2 class="me-section-title">reading &amp; writings</h2>
       <p class="me-bio">
-        I never read without notebookLM now. I never write on substack that is
-        meant to be read by notebookLM. Example of a text which is not meant to
-        be read via notebookLM,
-        <a href="https://webhomes.maths.ed.ac.uk/~v1ranick/papers/wigner.pdf" target="_blank" rel="noopener">https://webhomes.maths.ed.ac.uk/~v1ranick/papers/wigner.pdf</a>
-        and example of text that is meant to be read via notebookLM,
-        <a href="/blog/if-plato-had-notebooklm/">https://concavemirror.to/blog/if-plato-had-notebooklm/</a>
+        I read most of non-fictional articles, books and papers on notebookLM.
+        Some of my blogs are written assuming readers would have AI explaining
+        them. Why? because I can write lot more that way. I have assurance that
+        AI will be there to first give gist to readers, explain complex maths
+        in simple language. I can move on to talking more about higher level
+        interpretations of complex things this way.
       </p>
     </section>
   </article>


### PR DESCRIPTION
## Summary
Three small changes janhavi requested:

1. **`data/areas-of-ai`** — removed the three intro lines at the top ("everyone is talking about AI…" + "that alone tells you…" + "— listing and tracking down the sub-areas —"). Page now opens directly with the first `<Section>`.
2. **Post meta labels** — stopped rendering the `PostMeta` block on posts (the "is this finished 🍄 / opinion strength / evidence strength / ratio" block). The right column of the post header is now empty; the vertical and horizontal rules are preserved so the layout still has structure. `meta` fields remain in frontmatter (and in the content collection schema) so the block can be restored later without re-touching the content files.
3. **`/me` page reading & writings** — replaced the existing paragraph with the new prose. Note: I removed the two example URLs (wigner.pdf and if-plato-had-notebooklm) along with the old prose, since they illustrated a distinction in the old text that doesn't exist in the new one. Easy to add them back if you want — just say the word.

## Test plan
- [x] `npm run build` succeeds (23 pages)
- [ ] /data/areas-of-ai/ renders cleanly with no intro
- [ ] post pages (any of the blogs) no longer show meta labels but layout looks right
- [ ] /me reads correctly with the new paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)