### PR TITLE
blog: add "how i read and write"

### DIFF
--- a/src/content/blog/how-i-read-and-write.mdx
+++ b/src/content/blog/how-i-read-and-write.mdx
@@ -1,0 +1,19 @@
+---
+title: "how i read and write"
+date: 2026-05-24
+tags: []
+summary: "My actual protocol for surviving 30 open tabs — three tools, a notebook, and writing the blog as the way of finally reading everything."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 8
+  evidence_strength: 3
+---
+
+I have 30 tabs open currently and I want to read all of it. I want to read all the papers author has mentioned in related work, I do not want to miss reading that interesting philosophical take by a co-founder of Anthropic on this topic, oh Pop Leo said something on this I want to read that too.
+
+Reading and understanding 30 dense technical papers is impossible task. It will take me a week of serious effort to internalize them fully. So I usually end up never reading those tabs. Next time I again want to read 30 papers.
+
+I cannot stop doing this, so I realised why not try to design a proper protocol to make best out of it. Here is how exactly I read and write nowdays.
+
+I sit with three things open, claude, notebookLM and a notebook. I start talking with claude about the topic I want to learn, for example recently I was learning Mechanistic Interpretability. Claude points me to must check websites, keys people's social media handles, their pages, key blogs, foundational papers and I keep opening those tabs; sometimes skimming over them, otherwise I just keep them open in browser. After doing this for ~30 mins or so I would find my self going deeper into one of the sub topics. In this case it was implementing SAEs and training them on my machine. In parallel, I write down all of my thoughts, hypothesis, crazy things I wanna do in it. I usually do not much know what is possible and what is not possible at this point, so I get my craziest ideas at this point. Usually after 5-6 days of doing this, I would become more passimistic. So I utilise this time to note down all optimistic ideas. At this point I sometimes want to go deeper into specific paper with notebookLM. After doing this for a day or two, I start wrtiing first draft of my blog. I write down the story arc and it is here where I visit all those open tabs. I started with how brain neurons where some of the first work done on Mech Interp and read the paper, then i moved to the very first attempt by openAI to interpret information in LLMs from neurons (this is where I read their blog). By the time my blog's final draft is ready, I would have skimmed over or read most of the tabs that were open.


### PR DESCRIPTION
## Summary
- New blog page at `/blog/how-i-read-and-write/`.
- Janhavi's protocol for surviving 30 open tabs: claude + notebookLM + a physical notebook, with the blog itself as the artifact that finally pulls her through the tabs.
- Prose preserved **verbatim** per the standing rule. The casing, typos ("Pop Leo", "passimistic", "wrtiing", "nowdays", "much know what"), and lowercase title are intentional carry-overs from the dictated text; edit in this PR if you want them cleaned before merge.
- `\newParagraph` markers turned into paragraph breaks (3 inserted; the final long process paragraph kept as a single block since you didn't split it).

## Test plan
- [x] `npm run build` succeeds (23 pages)
- [x] Route emitted: `dist/blog/how-i-read-and-write/index.html`
- [x] Verify renders well on deployed preview
- [x] Verify it shows up in the /blog/ listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)