### PR TITLE
research: add "complex systems" index page

### DIFF
--- a/src/content/research/complex-systems.mdx
+++ b/src/content/research/complex-systems.mdx
@@ -1,0 +1,74 @@
+---
+title: "complex systems"
+date: 2026-05-24
+tags: []
+summary: "An index of essays on physics, language, epistemology, and behaviour — the threads that keep pulling me back to complex systems."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 7
+  evidence_strength: 5
+---
+
+Most of what I find interesting lives in *complex systems* — thermodynamics, chaos, language, statistics, why we feel what we feel. The list below is everything I've published on Substack that fits this thread, grouped roughly by theme. Each entry is linked; the colored tag is what theme it sits under.
+
+---
+
+<Section color="maroon" label="physics">
+
+**1. [Arrow of time](https://janhavivdadhania.substack.com/p/arrow-of-time)**
+On why time appears to flow in one direction — entropy as the asymmetric ratchet built into thermodynamics.
+
+**2. [Entropy dynamics in centralised and...](https://janhavivdadhania.substack.com/p/entropy-dynamics-in-centralised-and)**
+How entropy behaves differently in centralised vs distributed structures.
+
+**3. [Why can't Newton's physics predict...](https://janhavivdadhania.substack.com/p/why-cant-newtons-physics-predict)**
+Where classical determinism breaks down — chaos, sensitivity to initial conditions, the three-body problem.
+
+**4. [Does God play dice to decide your...](https://janhavidadhania.substack.com/p/does-god-play-dice-to-decide-your)**
+Quantum randomness, determinism, and what it means for free will (companion to the consciousness essay).
+
+</Section>
+
+<Section color="green" label="language & math">
+
+**5. [A mathematical look at why language...](https://janhavivdadhania.substack.com/p/mathematical-look-at-why-language)**
+Treating language as a formal system — what mathematics can and can't say about meaning.
+
+**6. [Words are bad. Numbers are even worse.](https://janhavivdadhania.substack.com/p/words-are-bad-numbers-are-even-worse)**
+Both of our main symbol systems lose information about the thing they're describing. A look at where each fails.
+
+</Section>
+
+<Section color="blue" label="epistemology">
+
+**7. [Chicken or egg — who came first?](https://janhavivdadhania.substack.com/p/chicken-or-egg-who-came-first)**
+The bootstrap problem dressed up as a riddle — how things that depend on each other can ever begin.
+
+**8. [Thinking about the hierarchy of sciences](https://janhavivdadhania.substack.com/p/thinking-about-hierarchy-of-sciences)**
+Physics → chemistry → biology → psychology → economics. What does it actually mean for one science to "sit on top of" another?
+
+**9. [Sometimes science is right, other...](https://janhavivdadhania.substack.com/p/some-times-science-is-right-other)**
+When the scientific method gets you to the truth and when it doesn't — and how to tell the difference.
+
+**10. [On statistics](https://janhavivdadhania.substack.com/p/on-statistics)**
+What statistics is actually doing, what it pretends to do, and where it stops being honest.
+
+</Section>
+
+<Section color="pink" label="behaviour & psychology">
+
+**11. [Why do we find Eren Yeager cool?](https://janhavivdadhania.substack.com/p/why-do-we-find-eren-yeager-cool)**
+On characters who break the rules we live by, and why we admire them rather than fear them.
+
+**12. [Can you compliment your girlfriend?](https://janhavivdadhania.substack.com/p/can-you-compliment-your-girlfriend)**
+A small communication question that opens up into a bigger one about how affection actually travels between people.
+
+**13. [I tried to find a solution to feeling...](https://janhavivdadhania.substack.com/p/i-tried-to-find-solution-to-feeling)**
+An attempt to treat an emotional problem as a systems problem — what worked, what didn't.
+
+</Section>
+
+---
+
+_Index, v1. Descriptions are short and inferred from titles — open the links for the actual essays. New entries get appended here when they fit the complex-systems thread._

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -25,6 +25,7 @@ export const site = {
     'blog/how-i-organise-my-agents',
     'research/seldon-framework',
     'research/ai-neuroscience',
+    'research/complex-systems',
     'data/areas-of-ai',
     'fantasy/me-and-moon',
   ] as string[],


### PR DESCRIPTION
## Summary
New page at `/research/complex-systems/` — index of 13 Substack essays grouped by theme.

Tag-by-theme using colored Section blocks (4 colors, 4 themes):

🟤 **physics** (4) — Arrow of time, Entropy dynamics, Newton's physics, God plays dice
🟢 **language & math** (2) — Mathematical look at language, Words vs numbers
🔵 **epistemology** (4) — Chicken or egg, Hierarchy of sciences, Science right/wrong, On statistics
🩷 **behaviour & psychology** (3) — Eren Yeager, Complimenting girlfriend, Solution to feeling

Numbering: 1-13 sequentially across themes, as janhavi requested. Ignored the messy original numbering and deduped two repeated URLs (the "feeling" essay appeared twice and was kept once).

**Descriptions are inferred from titles, not from reading the essays.** Flagged as such in the page footer. janhavi should review and fix any that miss the actual argument of the post.

Flagged as `unfinished_slugs` in `site.config.ts` since this is a living index that will grow.

## Test plan
- [x] `npm run build` succeeds (25 pages)
- [x] Route emitted: `dist/research/complex-systems/index.html`
- [ ] Eyeball preview — 13 entries in 4 colored blocks should read cleanly
- [ ] janhavi review: fix any title-vs-actual-essay mismatches in descriptions
- [ ] janhavi check: are the theme groupings the ones you'd pick, or should some entries move?

🤖 Generated with [Claude Code](https://claude.com/claude-code)