### PR TITLE
fantasy: add "guilt of selfish"

### DIFF
--- a/src/content/fantasy/guilt-of-selfish.mdx
+++ b/src/content/fantasy/guilt-of-selfish.mdx
@@ -5,7 +5,7 @@ tags: []
 summary: "An inner monologue of a Hungarian Jewish physicist invited to the Manhattan Project — written once raw, then once again, more slowly."
 draft: false
 meta:
-  is_finished: false
+  is_finished: true
   opinion_strength: 9
   evidence_strength: 2
 ---
@@ -33,6 +33,36 @@ Did you answer the letter?
 No, of course not. You never answer in time when the thing asked of you is real. An invitation to join them, to sit in rooms with men whose names already sound like history, to help them pull fire out of theory and lock it into metal. Oppenheimer. Bohr. Feynman. The kind of company you once would have crossed an ocean for. In fact, you did.
 
 So why hesitate now?
+
+Do not flatter yourself. This is not conscience suddenly blooming in a man who has lived so long by ambition. Back home they knew two things about you: that you were brilliant, and that anything standing between you and your work would be quietly, efficiently sacrificed. You were never kind. You were never noble. You were merely serious, which looked enough like virtue from a distance.
+
+And yet you cannot say yes.
+
+Why? Because it is a bomb? Because you have discovered morality? A little late for that, isn't it? You crossed borders while others waited for visas that never came. You saved your own mind and called it destiny. You have been living, quite comfortably, on the suffering of people less useful than you. Why grow delicate now, when the task is only to turn equations into casualties?
+
+Only. Yes, only.
+
+That is the trouble. You can hear the lie while you are saying it.
+
+You tell yourself you want to save lives, not end them. You tell yourself you want to return to pure thought, to logic, to first principles, to clean symbols that do not scream when they are used correctly. You tell yourself you were made for higher things. For mathematics. For truth. For work that does not stink of burned skin. And even in this, vanity survives. You do not want merely to be good. You want not to waste your talent. There you are again. Ruthless as ever, only dressed now in cleaner language.
+
+Perhaps morality is not even your field. That would be convenient. Let the priests decide. Let the statesmen decide. Let some certified expert in good and evil come stamp the paper and relieve you of choice. Tell me what is right, you think, and I will do it. Tell me whom to kill and whom to save and I will return, with relief, to my theorems.
+
+But the people who speak most confidently about morality always seem to you like idiots. That is the curse, isn't it? To be too intelligent to obey, too cowardly to believe, too proud to surrender judgment, and too human to endure it.
+
+You have spent your life wanting to be praised for what your mind can do. No one ever asked whether you were good. You never asked either. Intelligence was the only court that mattered. Now suddenly another tribunal has appeared, one with no formulas, no proofs, no axioms, and no appeal. And you are losing there.
+
+That is why you cannot answer the letter.
+
+Not because you are pure. Not because you are brave. Not because you are better than the men who will go.
+
+Because however selfish you have been, however much of your life has been built on escape, ambition, coldness, and the survival of the most useful, there is still some stubborn, humiliating part of you that does not want this guilt added to the rest.
+
+If you say yes, you will help build the thing.
+If you say no, others will build it without you.
+That is the comfort. That is the horror.
+
+And still, you cannot say yes.
 
 ---
 

--- a/src/content/fantasy/guilt-of-selfish.mdx
+++ b/src/content/fantasy/guilt-of-selfish.mdx
@@ -1,0 +1,41 @@
+---
+title: "guilt of selfish"
+date: 2026-05-24
+tags: []
+summary: "An inner monologue of a Hungarian Jewish physicist invited to the Manhattan Project — written once raw, then once again, more slowly."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 9
+  evidence_strength: 2
+---
+
+## Your Original Paragraph (lightly corrected)
+
+What are you thinking about? Your home, which is ashes? That is gone. Your aunts, uncles, friends, neighbours, classmates, and teachers are dead. Your girlfriend might be alive, but you don't know where she is. She anyway didn't deserve to come to America. She was a lowly musician. Worthless. You are the one who deserves it. You are smart. Clever.
+
+You will make friends here. You are finally living with the world's best brains, which you have always desired. You all will do science together. That reminds me, did you reply to the Manhattan Project's invitation letter? You were dying to meet Oppenheimer, Bohr, and Feynman. What are you waiting for? You have always been quite slow to reply to such opportunities.
+
+Why are you hesitating? Don't tell me you are not sure. Why? Guilt? You don't want to build a bomb? Is it really about the bomb? You left practically everyone you know back in Hungary to die. You have always been selfish. Since when has being a good person become your thing? Back at home, everyone agreed on at least two things: that you were smart and that you were ruthless about anything that came between you and your academics. So why are you unsure now? It is the opportunity of a lifetime to work alongside Oppenheimer, Bohr, and Feynman.
+
+Alright. It's okay. You want to go against it. Not build it. It feels wrong. You want to work to save lives, not take them. You also want to read *Principia Mathematica*. You don't want to waste your potential. There it is, the ruthlessness is back. Of course we don't want to waste our potential. This question of whether creating a bomb is right or wrong doesn't fall under your expertise. It is something to do with religion stuff. Morals. You are not an expert. Why can't you just do math? Why can't someone who is an expert in such worthless matters come and make a decision for you, so you can get to doing math? It sucks to do this housekeeping. But everyone who claims to be an expert in morals seems dumb. Being smart is a curse. You just wish someone smarter existed to tell you this is right and this is wrong, so you could let go of the guilt that is killing you.
+
+Why is it consuming you so much? You know how to do groundbreaking things in science and get praised for it; no one has ever praised you for being moral. What the hell is that? You are selfish. But why are you not able to say yes to the Manhattan Project?
+
+## Rewritten Version
+
+What are you thinking about now? Home? There is no home. Home is ash. Your aunts, your uncles, your teachers, your neighbors, your classmates, all of them scattered into smoke, into camps, into graves with no names. Your girlfriend may still be alive. Somewhere. Or not. You do not know. You left without knowing. You left because you could. Because between her life and yours, you knew which one the world was less willing to lose. She was only a musician. You were the mind. You were the one with a future. You were the one who deserved saving.
+
+And now here you are, exactly where you always wanted to be, among the finest brains in the world. Safe at last. Admired at last. Invited in. You should be happy. You should be grateful. You should already have written back.
+
+Did you answer the letter?
+
+No, of course not. You never answer in time when the thing asked of you is real. An invitation to join them, to sit in rooms with men whose names already sound like history, to help them pull fire out of theory and lock it into metal. Oppenheimer. Bohr. Feynman. The kind of company you once would have crossed an ocean for. In fact, you did.
+
+So why hesitate now?
+
+---
+
+## Similar works
+
+- [*The Maniac* — Benjamín Labatut](https://pushkinpress.com/book/the-maniac/) (Pushkin Press) — a novelistic biography of John von Neumann, written in the voices of those around him. Same era, same kind of guilt, same room.

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -29,6 +29,7 @@ export const site = {
     'research/complex-systems',
     'data/areas-of-ai',
     'fantasy/me-and-moon',
+    'fantasy/guilt-of-selfish',
   ] as string[],
 
   // External subscribe URL (homepage button).

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -29,7 +29,6 @@ export const site = {
     'research/complex-systems',
     'data/areas-of-ai',
     'fantasy/me-and-moon',
-    'fantasy/guilt-of-selfish',
   ] as string[],
 
   // External subscribe URL (homepage button).


### PR DESCRIPTION
## Summary
New fantasy page at `/fantasy/guilt-of-selfish/`. Inner-monologue piece on Manhattan-Project-era moral guilt — two passes, raw then rewritten. Pairs well with the *Social Circle of Scientists* blog now also on the site (both circling Los Alamos and the Hungarian-Jewish exiles).

Structure:
- **Your Original Paragraph (lightly corrected)** — janhavi's raw version
- **Rewritten Version** — the slower, more deliberate pass (cuts off at "So why hesitate now?" — left as-is, the piece is marked unfinished)
- **Similar works** — links *The Maniac* by Benjamín Labatut (Pushkin Press)

Flagged `fantasy/guilt-of-selfish` as unfinished in `site.config.ts` since the rewrite ends mid-thought.

## Test plan
- [x] `npm run build` succeeds (27 pages)
- [x] Route emitted: `dist/fantasy/guilt-of-selfish/index.html`
- [ ] Verify renders OK on preview
- [ ] janhavi continuation: the rewrite ends mid-sentence — push when you have the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)