### PR TITLE
blog: unlink "the map of the agent universe" (dangling page)

### DIFF
--- a/src/content/blog/the-map-of-the-agent-universe.mdx
+++ b/src/content/blog/the-map-of-the-agent-universe.mdx
@@ -3,7 +3,7 @@ title: "the map of the agent universe"
 date: 2026-04-10
 tags: []
 summary: "Silicons, sub-agents, branching, distributed worker soups, and the RAG/memory stack that lets all of this scale beyond a single 200k context window."
-draft: false
+draft: true
 meta:
   is_finished: false
   opinion_strength: 8

--- a/src/lib/clusters.ts
+++ b/src/lib/clusters.ts
@@ -25,12 +25,6 @@ export interface ClusterDef {
 export const clusters: Record<ClusterCollection, ClusterDef[]> = {
   blog: [
     {
-      id: 'left',
-      slugs: [
-        'the-map-of-the-agent-universe',
-      ],
-    },
-    {
       id: 'right',
       slugs: [
         'zoo-animals-and-context-windows',


### PR DESCRIPTION
## Summary
janhavi wants this page to stay accessible at its URL but no longer be linked from anywhere on the site — a dangling page.

Two changes:
1. `draft: true` in the post's frontmatter — drops it from the blog listing (`getPublishedEntries` filters drafts) and from the homepage feed.
2. Removed the now-dead `left` cluster def in `clusters.ts` (it only held this one slug).

The page is **still emitted** because `[slug].astro` uses unfiltered `getCollection('blog')`, so the URL `/blog/the-map-of-the-agent-universe/` still works for anyone with the direct link. The "unfinished writing" bar still shows on it (it's still in `unfinished_slugs` — left alone since the bar is semantically still true; tell me if you want it gone too).

## Test plan
- [x] `npm run build` succeeds (27 pages)
- [x] `grep` of `dist/blog/index.html` and `dist/index.html` for the slug returns 0 — no links anywhere
- [x] `dist/blog/the-map-of-the-agent-universe/index.html` still emitted
- [ ] Verify deployed `/blog/` listing no longer shows the entry
- [ ] Verify direct URL still loads after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)