### PR TITLE
mirror: add stack + hypothesis-gen agents to autoresearcher; research rabbit video to seldon

### DIFF
--- a/src/content/research/autoresearcher.mdx
+++ b/src/content/research/autoresearcher.mdx
@@ -12,13 +12,27 @@ meta:
 
 Before I clone Sakana's AI Scientist and run it, I want to skim every related paper — just in case something better than this already exists. Working dump below.
 
-The plan after the skim is small:
+## The stack I like
 
-1. Clone [AI Scientist v2](https://github.com/SakanaAI/AI-Scientist-v2/tree/main/ai_scientist) and get one end-to-end run going on a real research question.
-2. Run [ShinkaEvolve](https://github.com/SakanaAI/ShinkaEvolve) over Codeforces problems.
-3. Point AI Scientist at a new SAE hypothesis.
+The auto-research pipeline isn't one agent — it's three:
+
+1. **Hypothesis generation** — Google's AI co-scientist (or Stanford STORM / Edison Scientific) → produces a ranked list of research directions from the literature.
+2. **Experiment + writeup** — Sakana's AI Scientist v2 → takes one of those directions and runs the full ideation → BFTS experiments → paper pipeline.
+3. **Algorithm/code evolution** — Sakana's ShinkaEvolve → optionally evolves the code/algorithm inside the experiment step.
+
+AI Scientist v2 is built for *one hypothesis → one paper*, not for surveying. The first step belongs to a different class of tool.
 
 ---
+
+<Section color="gray" label="Hypothesis-generation agents — the missing piece">
+
+*The step that comes **before** AI Scientist. Survey the field, propose directions, debate, rank.*
+
+- **[Google — AI co-scientist (blog, Feb 2025)](https://research.google/blog/accelerating-scientific-breakthroughs-with-an-ai-co-scientist/)** — multi-agent system designed exactly for this. Generation → Reflection → Ranking → Evolution → Meta-review. Piloted on biomedical questions with domain experts.
+- **[Stanford STORM (open source)](https://github.com/stanford-oval/storm)** — multi-agent literature-survey writer. Closest open-source thing to a hypothesis-generation pipeline. Runnable today.
+- **[Edison Scientific — platform](https://platform.edisonscientific.com/)** — research-agent platform; placeholder note until I dig in.
+
+</Section>
 
 <Section color="maroon" label="AI Scientist v2 (Sakana)">
 

--- a/src/content/tools/seldon.mdx
+++ b/src/content/tools/seldon.mdx
@@ -16,3 +16,9 @@ All of my original ideas are generally 3-4 sentences long. I then read around th
 This is an hypothesis i am testing. I run different types of traversal algorithms on graph to certain depth and ask LLM to take that sub-graph and write an article using all nodes. All nodes are connected using edges so a second order ideas should naturally form(is the hypothesis). I want to see if different types of traversals generate clearly different types of articles. It is a running experiment, I will write on it after i am done running few iterations.
 
 Today, i gather my individual thoughts and write one article a week. With this system running, i will have traversal articles already written. I will now have not just individual ideas but also cluster of related ideas. I will be able to have this second order thinking done for me to consume, which might in turn enable me to have even longer ideas(which i call third order ideas).
+
+## research rabbit
+
+A partially similar tool.
+
+<iframe width="100%" height="400" style="max-width: 720px; display: block; margin: 1.5rem auto; aspect-ratio: 16/9;" src="https://www.youtube.com/embed/0jTRDxMS8T8" title="ResearchRabbit" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
## Summary

**autoresearcher (`/research/autoresearcher/`):**
- New **"The stack I like"** callout right after the intro, documenting the 3-layer flow janhavi liked: hypothesis-gen → AI Scientist v2 → ShinkaEvolve.
- New gray Section near the top — **"Hypothesis-generation agents — the missing piece"** — with:
  - 🔬 [Google — AI co-scientist (blog)](https://research.google/blog/accelerating-scientific-breakthroughs-with-an-ai-co-scientist/) — multi-agent, exactly designed for this
  - 🔬 [Stanford STORM (GitHub)](https://github.com/stanford-oval/storm) — open-source survey-writer
  - 🔬 [Edison Scientific platform](https://platform.edisonscientific.com/) — placeholder until janhavi digs in

**seldon (`/tools/seldon/`):**
- New **"research rabbit"** section at the bottom with embedded YouTube video (https://youtu.be/0jTRDxMS8T8), framed as a partially similar tool to Seldon.

## Test plan
- [x] `npm run build` succeeds (28 pages)
- [x] Both routes still emit
- [ ] Verify on deployed preview: the new gray section reads cleanly near top of autoresearcher; the YouTube embed works on /tools/seldon/

🤖 Generated with [Claude Code](https://claude.com/claude-code)