### PR TITLE
autoresearcher: add 'autoresearcher design' section at top with framework + sample runs

### DIFF
--- a/public/research/autoresearcher/co_scientist_prompt_sequence.html
+++ b/public/research/autoresearcher/co_scientist_prompt_sequence.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Co-Scientist — Sequence of LM Prompts in One Run</title>
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #5c5c5c;
+    --accent: #0b6e4f;
+    --bg: #fafaf7;
+    --code-bg: #f0efe9;
+    --border: #d6d4cc;
+  }
+  body {
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    max-width: 860px;
+    margin: 2.5rem auto;
+    padding: 0 1.25rem 4rem;
+  }
+  h1 { font-size: 1.6rem; margin: 0 0 0.25rem; }
+  h2 { font-size: 1.15rem; margin: 2.2rem 0 0.7rem; color: var(--accent); }
+  p { margin: 0.6rem 0; }
+  .lede { color: var(--muted); margin-bottom: 1.5rem; }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem 1.1rem;
+    overflow-x: auto;
+    font: 13.5px/1.5 "SF Mono", Menlo, Monaco, Consolas, monospace;
+  }
+  code {
+    background: var(--code-bg);
+    padding: 0.08em 0.35em;
+    border-radius: 4px;
+    font: 13.5px/1.4 "SF Mono", Menlo, Monaco, Consolas, monospace;
+  }
+  table {
+    border-collapse: collapse;
+    margin: 0.8rem 0;
+    font-size: 14.5px;
+  }
+  th, td {
+    border-bottom: 1px solid var(--border);
+    padding: 0.45rem 0.9rem 0.45rem 0;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { color: var(--muted); font-weight: 600; }
+  td.num { text-align: right; }
+  .total td { border-top: 1px solid var(--border); font-weight: 600; }
+  .note {
+    background: #fff;
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 1rem 0;
+    border-radius: 0 4px 4px 0;
+  }
+  .note strong { color: var(--accent); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Co-Scientist — Sequence of LM Prompts in One Run</h1>
+<p class="lede">The order LM calls fire when co-scientist processes one research goal. Captured from a code walkthrough of the Kaimen-Inc fork on 2026-06-02. Modeled after the companion STORM doc.</p>
+
+<h2>The sequence</h2>
+<pre>
+┌─ STAGE 0: Parse the goal (1 LM call) ─────────────────────────────────┐
+
+  1. ParseGoal(goal)
+     → prompt: "parse_goal.md"
+     → forced tool: record_research_plan
+     → produces a ResearchPlan that scopes the rest of the run
+     → fallback: if the model doesn't emit the tool, supervisor uses a
+       bare ResearchPlan and the session continues
+
+  ──── supervisor then enqueues N initial Generation tasks ────
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─ STAGE 1: Main loop ──────────────────────────────────────────────────┐
+│  task scheduler runs concurrency-many tasks at once;                  │
+│  every finished task may enqueue follow-ups;                          │
+│  loop terminates on budget / wall-clock / Elo stability / idle        │
+
+  ┌─ Generation (per initial task AND per Evolution offspring) ────┐
+  │                                                                │
+  │   2. Generation(goal, plan, system_feedback)                   │
+  │      → prompt: "generation_literature.md"                      │
+  │      → tool loop, up to 8 iterations:                          │
+  │           pubmed_search | arxiv_search | europe_pmc_search |   │
+  │           web_search | web_fetch | record_hypothesis (terminal)│
+  │      → each iteration = 1 LM call                              │
+  │      → result: new Hypothesis (if dedup passes)                │
+  │      → follow-up: enqueue Reflection                           │
+  └────────────────────────────────────────────────────────────────┘
+
+  ┌─ Reflection (1 per new hypothesis) ────────────────────────────┐
+  │                                                                │
+  │   3. Reflection(hypothesis)                                    │
+  │      → prompt: "reflection_review.md"  (= reflection.full)     │
+  │      → tool loop, up to 8 iterations:                          │
+  │           same lit-search tools + record_review (terminal)     │
+  │      → result: novelty / correctness / testability scores      │
+  │      → follow-up: enqueue Ranking.AddToTournament              │
+  └────────────────────────────────────────────────────────────────┘
+
+  ┌─ Ranking — Elo tournament ─────────────────────────────────────┐
+  │                                                                │
+  │   AddToTournament (non-LM): Elo=1200, schedule pairings        │
+  │                                                                │
+  │   4a. RankingDebate(A, B)   ← cold / Δelo<50  (low confidence) │
+  │       → prompt: "ranking.debate.md"                            │
+  │       → 1 LM call, no tool loop                                │
+  │                                                                │
+  │   4b. RankingPairwise(A, B) ← warm / Δelo≥50 (high confidence) │
+  │       → prompt: "ranking.pairwise.md"                          │
+  │       → 1 LM call, no tool loop                                │
+  │                                                                │
+  │   verdict ("better idea: 1|2") → Elo update → record match     │
+  │   every ~20 matches → Proximity reclusters (no LM)             │
+  └────────────────────────────────────────────────────────────────┘
+
+  ┌─ Evolution (fires when leaderboard matures) ───────────────────┐
+  │   trigger: ≥20 hypotheses, each with ≥3 matches                │
+  │   one EvolveTopHypotheses task runs 3 strategies in sequence:  │
+  │                                                                │
+  │   5a. EvolutionCombine(top-1 paired with most-distant)         │
+  │       → prompt: "evolution_combine.md"                         │
+  │   5b. EvolutionSimplify(top-1)                                 │
+  │       → prompt: "evolution_simplify.md"                        │
+  │   5c. EvolutionOutOfBox(top-5 as inspiration)                  │
+  │       → prompt: "evolution_out_of_box.md"                      │
+  │       (a 4th strategy, "feasibility", ships but is off in M3)  │
+  │                                                                │
+  │   each strategy = 1 tool_loop call (≤6 iters); offspring       │
+  │   re-enter the cycle via the Reflection follow-up rule.        │
+  └────────────────────────────────────────────────────────────────┘
+
+  ┌─ Meta-review (system feedback, fires periodically) ────────────┐
+  │   6. MetaReviewSystem                                          │
+  │      → prompt: "metareview_system.md"                          │
+  │      → forced tool: record_system_feedback                     │
+  │      → output injected into Generation / Evolution prompts as  │
+  │        steering for subsequent hypotheses                      │
+  │      → fires every ~50 matches when supervisor is idle         │
+  └────────────────────────────────────────────────────────────────┘
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─ STAGE 2: Finalize (1 LM call) ───────────────────────────────────────┐
+
+  7. MetaReviewFinal(top hypotheses, all reviews, all feedback)
+     → prompt: "metareview_final.md"
+     → no tools; the model writes prose directly
+     → SAVED as data/artifacts/&lt;session_id&gt;/final/overview.md
+
+└──────────────────────────────────────────────────────────────────────┘
+</pre>
+
+<h2>Concrete call count for our run</h2>
+<p>Run config: <code>--n 3</code> initial hypotheses, <code>--budget-usd 100</code>, <code>--wall-clock 900</code> (15&nbsp;min), <code>concurrency=2</code>, default <code>max_ideas=60</code>, <code>max_matches_per_idea=12</code>, all <code>tool_loop.*_max_iters</code> at defaults. Bottleneck for us is wall-clock and <code>claude -p</code> subprocess latency (~3-5&nbsp;s of cold-start per LM call), not budget.</p>
+
+<table>
+  <thead>
+    <tr><th>Prompt</th><th class="num">Times fired</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>parse_goal</code></td><td class="num">1</td><td>once at session start</td></tr>
+    <tr><td><code>generation_literature</code></td><td class="num">3 – 8</td><td>3 initial + offspring from Evolution; each is a full tool loop of 1 – 8 LM calls</td></tr>
+    <tr><td><code>reflection_review</code></td><td class="num">3 – 8</td><td>one Reflection per new hypothesis; each is a tool loop</td></tr>
+    <tr><td><code>ranking.debate</code></td><td class="num">5 – 12</td><td>cold matches and low-Δelo pairs (high-verbosity mode)</td></tr>
+    <tr><td><code>ranking.pairwise</code></td><td class="num">8 – 20</td><td>warm matches with Δelo≥50 (fast mode); dominates once the leaderboard is established</td></tr>
+    <tr><td><code>evolution_combine</code></td><td class="num">0 – 2</td><td>only fires after leaderboard maturity (≥20 hypotheses, ≥3 matches each); may not trigger at all in a 15-min subprocess-bound run</td></tr>
+    <tr><td><code>evolution_simplify</code></td><td class="num">0 – 2</td><td>same maturity gate</td></tr>
+    <tr><td><code>evolution_out_of_box</code></td><td class="num">0 – 2</td><td>same maturity gate</td></tr>
+    <tr><td><code>metareview_system</code></td><td class="num">0 – 2</td><td>every ~50 matches; small runs hit this 0–1 times</td></tr>
+    <tr><td><code>metareview_final</code></td><td class="num">1</td><td>always, once at termination</td></tr>
+    <tr class="total"><td>Total LM calls (incl. tool-loop iterations)</td><td class="num">~35 – 80</td><td>wide because tool loops can short-circuit on the first <code>record_*</code> call or run all 8 iterations</td></tr>
+  </tbody>
+</table>
+
+<h2>Notes about the order</h2>
+
+<div class="note">
+  <strong>Ranking has no tool loop.</strong> Unlike Generation, Reflection, and Evolution, each Ranking match is a single direct LM call — no literature search, no nested iterations. That's why the tournament can rack up many matches quickly while Generation and Reflection are slower per-hypothesis. The verdict is parsed from the trailing text via a regex looking for <code>better idea: 1|2</code>.
+</div>
+
+<div class="note">
+  <strong>Reflection.full, Ranking.debate vs. Ranking.pairwise are alternatives</strong> — only one fires per invocation. Reflection ships three modes in the supplementary pseudocode (<code>full</code>, <code>verification</code>, <code>observation</code>) but only <code>full</code> is wired up in this fork. Ranking's <code>_select_mode()</code> picks debate when either match counter is &lt; 2 or the Elo gap is &lt; 50, otherwise pairwise. Evolution's three strategies, by contrast, are <em>not</em> mutually exclusive — every EvolveTopHypotheses task runs combine + simplify + out_of_box in sequence.
+</div>
+
+<div class="note">
+  <strong>The tool loop is the load-bearing inner mechanism.</strong> Each Generation / Reflection / Evolution task is one outer task but up to 8 (Generation, Reflection) or 6 (Evolution) inner LM calls — one per assistant turn in the assistant ↔ tool_use ↔ tool_result loop. Loop ends when the model emits a "terminal" tool (<code>record_hypothesis</code>, <code>record_review</code>, <code>record_system_feedback</code>) or hits the max-iters cap. On the final allowed iteration the supervisor optionally forces the terminal tool so the run commits instead of looping on yet another search.
+</div>
+
+<div class="note">
+  <strong>Meta-review fires twice in two different shapes.</strong> <code>metareview_system</code> is steering feedback that gets <em>injected back</em> into Generation and Evolution prompts on subsequent turns — it shapes future hypotheses. <code>metareview_final</code> is the readable end-of-run document. Only the final overview is what you sit down and read.
+</div>
+
+<div class="note">
+  <strong>Proximity is non-LM.</strong> Embeddings (Voyage → OpenAI → hash fallback) plus sklearn clustering. It schedules a recluster every ~20 matches to drive informative pair selection — but it never calls the LM. Its presence in the agent roster is what makes co-scientist "7 agents" and not "6 LM agents".
+</div>
+
+<hr>
+<p class="lede">Source: <code>hypothesisgenerator/Co-Scientist/co_scientist/agents/</code> — see <code>supervisor.py</code>, <code>generation.py</code>, <code>reflection.py</code>, <code>ranking.py</code>, <code>evolution.py</code>, <code>proximity.py</code>, <code>metareview.py</code>. Tool-loop machinery in <code>co_scientist/llm/tool_loop.py</code>. Prompt templates in <code>config/prompts/</code> (14 Jinja2 markdown files). Limits and budget shares in <code>config/default.toml</code>.</p>
+
+</body>
+</html>

--- a/public/research/autoresearcher/co_scientist_sae_overview.md
+++ b/public/research/autoresearcher/co_scientist_sae_overview.md
@@ -1,0 +1,47 @@
+# Executive Summary
+
+The tournament converged on a single top-ranked hypothesis exploring how Sparse Autoencoder (SAE) feature-splitting hierarchies might encode causal structure within neural networks [H-hyp_bd0afd5bcfef5d20]. The core idea — that features learned at smaller dictionary sizes are causally more central than those appearing only at larger sizes — is a compelling operationalization of mechanistic interpretability that bridges representation learning and causal inference. While the tournament was narrow in scope (only one hypothesis reached final ranking), this direction is well-motivated by recent empirical work on SAE scaling and feature geometry. Acting on it could yield a principled, falsifiable framework for evaluating whether SAEs do more than describe activations — whether they actually illuminate *how* models compute.
+
+---
+
+# Main Research Directions
+
+## 1. SAE Feature-Splitting as a Causal Concept Hierarchy
+
+- **The direction.** Train SAEs at multiple dictionary sizes on the same model and test whether "root" features (small SAEs) have greater causal effect on downstream task performance than "leaf" features (large SAEs).
+- **Why it's promising.** [H-hyp_bd0afd5bcfef5d20] proposes a directly measurable prediction: activation-patching effect sizes should decrease monotonically as features appear at larger and larger dictionary scales. This is grounded in the well-documented phenomenon of feature splitting (first described in Anthropic's monosemanticity work) and connects it to a causal rather than merely descriptive account of SAE features. The hypothesis is attractive because it generates a concrete hierarchy that could be validated or refuted with existing tooling.
+- **Open questions.**
+  - Does feature splitting actually produce a *tree* structure, or a more tangled DAG? If features do not split cleanly, the causal-centrality prediction may not hold.
+  - Are activation-patching effect sizes a reliable proxy for "causal centrality," or do they conflate direct and indirect causal pathways?
+  - Does the hierarchy generalize across model families (e.g., GPT-style vs. BERT-style architectures), or is it an artifact of a specific training regime?
+  - Could the observed hierarchy reflect data-frequency statistics rather than genuine causal structure in the model?
+- **First experiment.** Train SAEs at 3–5 dictionary sizes (e.g., 512, 2048, 8192, 32768 features) on a single residual-stream layer of a small open-weight LLM (e.g., Pythia-1.4B or GPT-2-XL). For each feature, compute activation-patching effect sizes on 2–3 diverse downstream tasks (e.g., factual recall, syntax, sentiment). Test whether mean effect size is significantly higher for features present only in the smallest SAE vs. those appearing only in the largest. A Spearman rank correlation between "first-appearance dictionary size" and "median patching effect size" provides a single summary statistic. This can be completed in 4–8 weeks with standard interpretability libraries (TransformerLens, SAELens).
+
+---
+
+# Convergence and Divergence
+
+Given that the tournament produced only **one ranked hypothesis**, there is no convergence or divergence across competing directions to report directly. This is an important caveat (see below). The single hypothesis, [H-hyp_bd0afd5bcfef5d20], sits at the intersection of two independently active research threads:
+
+- **SAE scaling / feature geometry** (e.g., Anthropic's superposition and monosemanticity work): concerned with *what* features SAEs learn.
+- **Causal mediation analysis in neural networks** (e.g., activation patching, path patching): concerned with *which* computations matter for behavior.
+
+These threads are currently treated as largely orthogonal in the literature; this hypothesis proposes they are structurally linked. Whether that link is real or coincidental is the central open question.
+
+---
+
+# Caveats and Limitations
+
+1. **Extremely thin tournament coverage.** Only one hypothesis was evaluated; the system did not explore alternative interpretability approaches (probing classifiers, circuits analysis, concept bottleneck models, TCAV, etc.) that could serve as controls or baselines for assessing SAE utility.
+
+2. **No reviews were submitted.** The lone hypothesis carries no peer-style evaluation from other agents, meaning its assumptions have not been stress-tested within the tournament itself. The open questions listed above are speculative rather than tournament-validated.
+
+3. **The causal-centrality claim is theoretically underspecified.** "Causal centrality" in neural networks is contested; activation patching measures a specific interventional quantity that can be confounded by feature correlations, attention sink effects, and nonlinear interactions. A domain expert would likely push back on equating patching effect size with causal importance.
+
+4. **Feature splitting may not be hierarchical.** The hypothesis assumes splitting is tree-structured, but empirical evidence (e.g., from Bricken et al. 2023 and follow-ups) suggests feature geometry is complex. The causal-tree framing may impose more structure than exists.
+
+5. **Evaluation tasks are unspecified.** The hypothesis mentions "diverse downstream tasks" but does not define what counts as a sufficient diversity. Task choice could heavily influence whether the hierarchy appears clean or noisy.
+
+6. **No exploration of failure modes of SAEs as an interpretability tool.** The research goal is to *test* SAEs — a rigorous test requires null hypotheses and adversarial evaluations (e.g., do SAE features explain model errors? do they transfer across fine-tuning?). The tournament did not surface these critical perspectives.
+
+**Recommendation for the scientist:** Before investing heavily in [H-hyp_bd0afd5bcfef5d20], run a broader hypothesis-generation phase that includes competing interpretability paradigms and explicit null hypotheses about SAE limitations. The current hypothesis is promising but represents a narrow slice of the design space.

--- a/public/research/autoresearcher/storm_prompt_sequence.html
+++ b/public/research/autoresearcher/storm_prompt_sequence.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>STORM — Sequence of LM Prompts in One Run</title>
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #5c5c5c;
+    --accent: #0b6e4f;
+    --bg: #fafaf7;
+    --code-bg: #f0efe9;
+    --border: #d6d4cc;
+  }
+  body {
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    max-width: 860px;
+    margin: 2.5rem auto;
+    padding: 0 1.25rem 4rem;
+  }
+  h1 { font-size: 1.6rem; margin: 0 0 0.25rem; }
+  h2 { font-size: 1.15rem; margin: 2.2rem 0 0.7rem; color: var(--accent); }
+  p { margin: 0.6rem 0; }
+  .lede { color: var(--muted); margin-bottom: 1.5rem; }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem 1.1rem;
+    overflow-x: auto;
+    font: 13.5px/1.5 "SF Mono", Menlo, Monaco, Consolas, monospace;
+  }
+  code {
+    background: var(--code-bg);
+    padding: 0.08em 0.35em;
+    border-radius: 4px;
+    font: 13.5px/1.4 "SF Mono", Menlo, Monaco, Consolas, monospace;
+  }
+  table {
+    border-collapse: collapse;
+    margin: 0.8rem 0;
+    font-size: 14.5px;
+  }
+  th, td {
+    border-bottom: 1px solid var(--border);
+    padding: 0.45rem 0.9rem 0.45rem 0;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { color: var(--muted); font-weight: 600; }
+  td.num { text-align: right; }
+  .total td { border-top: 1px solid var(--border); font-weight: 600; }
+  .note {
+    background: #fff;
+    border-left: 3px solid var(--accent);
+    padding: 0.7rem 1rem;
+    margin: 1rem 0;
+    border-radius: 0 4px 4px 0;
+  }
+  .note strong { color: var(--accent); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+</style>
+</head>
+<body>
+
+<h1>STORM — Sequence of LM Prompts in One Run</h1>
+<p class="lede">The strict chronological order of LM calls when STORM processes one topic. Captured from a code walkthrough on 2026-06-02.</p>
+
+<h2>The sequence</h2>
+<pre>
+┌─ STAGE 1: Knowledge Curation ─────────────────────────────────────────┐
+
+  1. FindRelatedTopic(topic)
+     → returns ~5 Wikipedia URLs for related subjects
+     → [non-LM]: HTTP fetch each URL, BeautifulSoup-parse the TOC
+
+  2. GenPersona(topic, related_TOCs)
+     → returns N personas as a numbered list
+     → [non-LM]: prepend hardcoded "Basic fact writer" → final list of N+1 personas
+
+  ──── then for EACH persona (run in parallel via thread pool) ────
+
+    REPEAT max_conv_turn times:
+
+      3. AskQuestionWithPersona(topic, persona, conv_history_so_far)
+            ↑ (falls back to AskQuestion if persona is empty)
+         → returns the next question this persona wants to ask the "expert"
+         → break early if question is "" or starts with "Thank you so much..."
+
+      4. QuestionToQuery(topic, question)
+         → returns ~3 search queries
+         → [non-LM]: retriever.fetch(queries) → web snippets
+
+      5. AnswerQuestion(topic, question, snippets)
+         → returns expert's answer (with citation markers)
+         → append (question, answer, queries, results) to conv_history
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─ STAGE 2: Outline Generation ─────────────────────────────────────────┐
+
+  6. WritePageOutline(topic)
+     → returns draft outline from parametric knowledge alone
+     → SAVED as direct_gen_outline.txt
+
+  7. WritePageOutlineFromConv(topic, old_outline=draft, conv=all_transcripts)
+     → returns refined outline using the conversations
+     → SAVED as storm_gen_outline.txt
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─ STAGE 3: Article Generation ─────────────────────────────────────────┐
+
+  ──── for EACH top-level section in storm_gen_outline (parallel) ────
+
+    [non-LM]: ConvToSection — gather conversation turns relevant to this section
+
+    8. WriteSection(topic, section_outline, relevant_snippets)
+       → returns section text with [n]-style citations
+
+  ──── assemble all sections in outline order → storm_gen_article.txt ────
+
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─ STAGE 4: Article Polishing ──────────────────────────────────────────┐
+
+  9.  WriteLeadSection(topic, full_article)
+      → returns the summary paragraph that goes at the top
+
+  10. PolishPage(full_article_with_lead)
+      → optional dedupe pass over the whole article
+      → SAVED as storm_gen_article_polished.txt
+
+└──────────────────────────────────────────────────────────────────────┘
+</pre>
+
+<h2>Concrete call count for our run</h2>
+<p>Run config: <code>max_perspective=2</code> → 3 personas total (default + 2), <code>max_conv_turn=2</code>.</p>
+
+<table>
+  <thead>
+    <tr><th>Prompt</th><th class="num">Times fired</th><th>Why</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>FindRelatedTopic</code></td><td class="num">1</td><td>once per topic</td></tr>
+    <tr><td><code>GenPersona</code></td><td class="num">1</td><td>once per topic</td></tr>
+    <tr><td><code>AskQuestionWithPersona</code></td><td class="num">6</td><td>3 personas × 2 turns</td></tr>
+    <tr><td><code>QuestionToQuery</code></td><td class="num">6</td><td>one per turn</td></tr>
+    <tr><td><code>AnswerQuestion</code></td><td class="num">6</td><td>one per turn</td></tr>
+    <tr><td><code>WritePageOutline</code></td><td class="num">1</td><td>the draft</td></tr>
+    <tr><td><code>WritePageOutlineFromConv</code></td><td class="num">1</td><td>the refinement</td></tr>
+    <tr><td><code>WriteSection</code></td><td class="num">~10</td><td>one per top-level section of the outline</td></tr>
+    <tr><td><code>WriteLeadSection</code></td><td class="num">1</td><td>summary</td></tr>
+    <tr><td><code>PolishPage</code></td><td class="num">1</td><td>dedupe</td></tr>
+    <tr class="total"><td>Total</td><td class="num">~34</td><td>matches the log of our actual run</td></tr>
+  </tbody>
+</table>
+
+<h2>Two notes about the order</h2>
+
+<div class="note">
+  <strong>AskQuestion vs. AskQuestionWithPersona</strong> are alternatives — only one fires per turn. <code>AskQuestion</code> is the bare fallback when no persona is supplied; STORM's main path always supplies a persona, so in practice you only see <code>AskQuestionWithPersona</code> in real runs. That's why the inventory lists 11 prompts but only 10 fire in any given run.
+</div>
+
+<div class="note">
+  <strong>Within Stage 1</strong>, the N personas run in parallel (one thread per persona via <code>max_thread_num</code>), so the <em>wall-clock</em> order is interleaved. But within a single persona's thread, the turn-loop is strictly sequential: AskQuestion → QuestionToQuery → AnswerQuestion → next turn.
+</div>
+
+<hr>
+<p class="lede">Source: <code>stanford-storm/storm/knowledge_storm/storm_wiki/modules/</code> — see <code>knowledge_curation.py</code>, <code>persona_generator.py</code>, <code>outline_generation.py</code>, <code>article_generation.py</code>, <code>article_polish.py</code>.</p>
+
+</body>
+</html>

--- a/public/research/autoresearcher/storm_sae_article.txt
+++ b/public/research/autoresearcher/storm_sae_article.txt
@@ -1,0 +1,227 @@
+# summary
+
+**Sparse autoencoders** (**SAEs**) are a class of neural network architectures that have emerged as a prominent tool in mechanistic interpretability, a subfield of artificial intelligence research that aims to open the black box of neural networks and rigorously explain the underlying computations they perform.[1][2] Their primary application is the decomposition of the complex, superposed internal representations of large language models (LLMs) into components that correspond to distinct, human-interpretable semantic concepts.[3][4] This addresses the phenomenon of **polysemanticity**, whereby individual neurons or groups of neurons within a neural network encode a greater number of concepts than might be expected, often activating in response to multiple unrelated inputs — a property that renders direct inspection of raw model activations difficult to interpret.[5][6]
+SAEs achieve this decomposition through an overcomplete, sparse architecture: the hidden layer contains more dimensions than the input, and sparsity constraints — typically enforced via L1 regularization — ensure that only a small subset of neurons activate for any given input.[3][7][8] By training on the activations of a target network layer, SAEs learn to reconstruct those activations while effectively disentangling superimposed features into more **monosemantic** representations, meaning each extracted feature tends to correspond to a single, coherent concept rather than a mixture of unrelated ones.[9][10] Research using toy models — small ReLU networks trained on synthetic data with sparse input features — has helped clarify the theoretical basis for superposition and the conditions under which it arises.[11] Scaling laws governing the relationships between sparsity, autoencoder size, and language model size have also been established to guide practical training decisions.[12]
+Beyond their interpretive value, SAEs have demonstrated utility as mechanisms for behavioral intervention, enabling researchers to steer model outputs by artificially activating or suppressing specific features during inference — a capacity closely tied to the monosemanticity of the extracted features and used as evidence that they are causally relevant components of model computation, not merely correlational artifacts.[9][10] Several architectural extensions have been proposed to improve scalability and expressiveness, including the Switch SAE, which leverages conditional computation to efficiently expand the feature space,[1] and approaches that move from fixed-dimensional to functional representations, broadening SAEs from static concept detectors to richer analytical tools.[13] Application of SAEs has further extended to vision-language models such as CLIP, where they similarly enhance the interpretability of multimodal representations.[14][15]
+Despite these advances, SAEs face notable limitations and criticisms. Benchmarking research — including evaluations such as AXBENCH — has shown that SAEs can underperform simpler supervised methods such as linear probes on specific interpretation tasks, raising questions about the universality of their advantages.[3] The disentanglement they achieve is not always complete, and individual SAE features do not invariably correspond cleanly to human-interpretable units of meaning.[11] Critics have further questioned whether SAE-derived features genuinely meet the mechanistic interpretability standard of being correct, parsimonious, and faithful to underlying model computations, or whether some features reflect artifacts of the SAE training process itself.[2][11] Architectural standardization remains an open challenge, as ongoing experimentation with novel designs reflects the immaturity of the field.[16]
+
+# Background
+
+Mechanistic interpretability is a subfield of artificial intelligence research that aims to open the black box of neural networks and rigorously explain the underlying computations they perform[1]. The field seeks to produce explanations of neural networks that are correct, parsimonious, and faithful to the actual mechanisms at work[2].
+A central challenge in interpreting large language models (LLMs) is the phenomenon of **polysemanticity**, in which individual neurons or groups of neurons encode a greater number of concepts than might be expected, often firing on multiple unrelated inputs[5][6]. This occurs because neural networks tend to superimpose multiple representations within the same set of neurons, making it difficult to assign a single, coherent meaning to any individual unit[3].
+Sparse autoencoders (SAEs) have emerged as a promising approach to address this problem. By learning an overcomplete, sparse representation of neural activations, SAEs effectively disentangle these superimposed features, decomposing the complex representations within LLMs into components that correspond to distinct semantic concepts[3][4]. The features extracted by SAEs have been shown to be more interpretable and monosemantic than directions identified by alternative approaches[9], meaning each extracted feature tends to correspond to a single, coherent concept rather than a mixture of unrelated ones[10].
+The theoretical basis for why neural networks exhibit polysemanticity has been investigated using toy models — small ReLU networks trained on synthetic data with sparse input features — which help illuminate how and when models develop superposed representations[11]. SAEs address this by revealing the hidden mechanisms underlying neural networks, producing striking and interpretable results[17]. Research has further examined scaling laws with respect to sparsity, autoencoder size, and language model size, providing a principled understanding of how SAE performance evolves[12].
+Beyond LLMs, SAEs have also been applied to Vision-Language Models (VLMs) such as CLIP, where they similarly enhance the monosemanticity of individual neurons, with sparsity and wider latent spaces being key factors in this improvement[14][15].
+
+# Architecture and Design
+
+Sparse autoencoders (SAEs) are designed to decompose the complex, superposed representations within large language models (LLMs) into features that correspond to distinct semantic concepts.[4] At their core, an SAE transforms an input vector into an intermediate representation, which can be of higher, equal, or lower dimension compared to the original input.[18] In practice, SAEs are most commonly configured as overcomplete networks, meaning the intermediate representation has a higher dimensionality than the input, allowing the model to learn a richer set of features.[3]
+
+## Sparsity Constraints
+
+A defining characteristic of SAEs is the enforcement of sparsity, which ensures that only a small subset of neurons activate for any given input.[7] This constraint is critical for learning high-level, disentangled features, as it prevents the network from relying on dense, overlapping activations.[19] Sparsity is commonly enforced through L1 regularization, which penalizes the magnitude of activations and encourages the learned representations to be sparse.[7][8] By training an SAE to reconstruct the activations of a target network layer while enforcing these sparsity constraints, the architecture can effectively disentangle superimposed features that would otherwise be difficult to interpret.[3]
+
+## Feature Extraction and Monosemanticity
+
+The primary goal of this architectural design is the extraction of relatively monosemantic features — that is, individual neurons or latent directions that correspond to single, interpretable concepts rather than a mixture of concepts.[10][20] SAEs address the phenomenon of superposition in neural networks, whereby a model encodes more features than it has dimensions by representing them as overlapping, distributed patterns.[3] The overcomplete, sparse representation learned by an SAE effectively disentangles these superimposed signals, producing features that are both interpretable and largely invisible to the original model's computation.[10]
+
+## Novel Architectural Variants
+
+Beyond the standard formulation, several architectural innovations have been proposed to improve SAE performance and scalability. One such approach introduces a stochastic encoder network with a novel gating mechanism, offering benefits in terms of feature quality and training stability.[16] Another variant, the Switch SAE, leverages conditional computation to efficiently scale SAEs to significantly larger numbers of features than would otherwise be tractable.[1] Additionally, research has explored moving from fixed-dimensional to functional representations, which extends the expressive capacity of SAEs from detectors of discrete concepts to richer, more continuous representational structures.[13] Systematic studies of scaling laws with respect to sparsity, autoencoder size, and language model size have further informed optimal architectural choices across different deployment settings.[12]
+
+# Training
+
+Sparse autoencoders (SAEs) are trained by optimizing a reconstruction objective over the activations of a target network layer while simultaneously enforcing sparsity constraints on the learned representations.[19] The core training procedure involves presenting the autoencoder with neural activations drawn from a pretrained language model, typically from residual stream positions, and requiring the autoencoder to reconstruct those activations using only a small subset of its available latent features.[20]
+
+## Sparsity Enforcement
+
+Sparsity is a central requirement of the training process, as it encourages the autoencoder to learn high-level, disentangled features rather than entangled or polysemantic ones.[7] Without sparsity, a standard autoencoder would distribute information across all neurons simultaneously, failing to isolate meaningful individual features.[3] The most common mechanism for enforcing sparsity during training is L1 regularization, which penalizes the magnitude of activations in the hidden layer and thereby drives the model toward solutions in which only a small subset of neurons activate for any given input.[7]
+
+## Overcomplete Representations
+
+SAEs are designed to learn overcomplete dictionaries — that is, the number of latent features in the autoencoder significantly exceeds the dimensionality of the input activations.[3] This overcomplete structure allows the model to represent a rich variety of concepts while maintaining sparsity, effectively disentangling features that may be superimposed within the original network's activations.[3] The resulting latent directions tend to be more monosemantic and interpretable than those identified by alternative dimensionality-reduction approaches.[9]
+
+## Scaling Considerations
+
+Research has systematically examined how SAE training scales with respect to sparsity levels, autoencoder size, and the size of the underlying language model.[12] Wider latent spaces — i.e., autoencoders with more features — have been found to significantly enhance the monosemanticity of individual neurons.[15] To address the computational cost of scaling to very large feature sets, novel architectures such as the Switch SAE have been proposed, leveraging conditional computation to efficiently expand the number of learnable features.[1] Scaling laws governing the interplay between sparsity, feature count, and model size have become an active area of investigation in order to guide practical training decisions.[12]
+
+## Unsupervised Feature Discovery
+
+A notable property of the SAE training procedure is that it is fully unsupervised, requiring no human-labeled data or predefined concept taxonomies.[21][20] Features emerge purely from the structure of the model's internal activations, and the resulting representations have been found to correspond to human-interpretable concepts.[22] This unsupervised nature makes SAE training broadly applicable across different model families, including both large language models and vision-language models such as CLIP.[14]
+
+# Computational Considerations
+
+Training and deploying sparse autoencoders (SAEs) at scale introduces significant computational challenges. Large language models require substantial GPU memory for inference, and augmenting them with SAEs compounds these resource demands.[23] As a result, researchers have investigated scaling laws to better understand how to allocate computational resources efficiently when training SAEs.[24]
+
+## Scaling Laws
+
+Systematic studies of SAE scaling behavior examine the relationships between sparsity, autoencoder size, and language model size, providing empirical guidance for practitioners seeking to balance interpretability quality against computational cost.[12] These scaling laws can be used to guide the training of sparse autoencoders, helping researchers avoid over- or under-parameterized configurations.[24]
+
+## Architectural Efficiency
+
+Several architectural innovations have been proposed to reduce the computational footprint of SAEs without sacrificing interpretability quality. The Switch SAE introduces conditional computation to efficiently scale SAEs to many more features, leveraging sparsity at the architectural level to limit unnecessary computation.[1] Similarly, KronSAE addresses encoder bottlenecks by decomposing the latent space into head-wise components using Kronecker-structured representations, reducing parameter counts while maintaining expressive capacity.[25] Tensor-SAE takes a related approach, decoding through a learned bank of rank-1 tensor atoms, which imposes structured factorization to improve efficiency.[26]
+
+## Functional and Overcomplete Representations
+
+A core computational trade-off in SAE design involves the dimensionality of the hidden layer. Standard autoencoders compress input to a smaller-dimensional hidden representation, whereas SAEs intentionally use overcomplete representations — hidden layers larger than the input — to disentangle superimposed features.[27][3] Moving from fixed-dimensional to functional representations has been shown to extend SAEs beyond simple concept detectors, though this comes with added complexity in training and inference.[13] Enforcing sparsity constraints during reconstruction, typically via L1 regularization, helps manage this complexity by ensuring only a small number of features are active at any given time, yielding more tractable and interpretable activations.[19]
+
+# Application to Language Models
+
+Sparse autoencoders (SAEs) have emerged as a prominent tool in the field of mechanistic interpretability, which aims to open the black box of neural networks and rigorously explain their underlying computations.[1] By training a sparse autoencoder to reconstruct the activations of a target network layer while enforcing sparsity constraints, SAEs can disentangle superimposed representations that are otherwise difficult to interpret.[3]
+
+## Feature Discovery in Language Models
+
+A central application of SAEs to language models involves the unsupervised discovery of interpretable, monosemantic features. Researchers have demonstrated that SAEs can find interpretable features in the residual streams of real large language models (LLMs) using scalable, unsupervised methods.[20] These extracted features tend to be relatively monosemantic, meaning each feature corresponds to a distinct and human-interpretable concept, and are effectively invisible to standard analysis techniques.[10] Recent work has confirmed that SAEs are broadly able to discover such human-interpretable features across a variety of language model architectures.[22]
+
+## Scaling Properties
+
+The effectiveness of SAEs in language model interpretability has been studied systematically with respect to multiple dimensions of scale. Research has examined scaling laws governing sparsity, autoencoder size, and language model size, providing empirical grounding for how SAE performance changes as models grow larger.[12] These findings help guide practical decisions about SAE architecture when applied to frontier-scale language models.
+
+## Steerability and Control
+
+Beyond interpretability, SAEs have gained attention as a means to improve the steerability of LLMs.[28] By identifying and isolating specific features within a model's activations, SAEs provide a mechanism through which targeted interventions can be made to influence model behavior, offering a more principled approach to model control than black-box fine-tuning methods.
+
+## Limitations Relative to Linear Probes
+
+Despite their promise, SAEs show certain limitations when compared to alternative interpretability approaches such as linear probes. Benchmark evaluations such as AXBENCH have highlighted cases where SAEs underperform linear probes for specific language model interpretation tasks, indicating that SAEs are not universally superior and that the choice of interpretability method should be informed by the task at hand.[3]
+
+## Extension to Vision-Language Models
+
+The application of SAEs has been extended beyond text-only language models to vision-language models (VLMs) such as CLIP. Research has investigated using SAEs to decompose the internal representations of VLMs, enhancing their interpretability by identifying features that span both visual and linguistic modalities.[14] Structured variants such as Tensor-SAE, which decodes through a learned bank of rank-1 tensor atoms organized along color, height, and width dimensions, have also been proposed to better capture the spatial structure of visual representations.[26]
+
+# Discovered Features
+
+Sparse autoencoders (SAEs) have proven effective at decomposing the complex, superposed representations within large language models (LLMs) into features that correspond to distinct semantic concepts.[4] A central motivation for applying SAEs to language models is the problem of **polysemanticity**, the phenomenon in which individual neurons or groups of neurons in neural networks often encode a greater number of concepts than might be expected, firing on multiple unrelated inputs.[5][6] This entanglement of concepts within single neurons makes direct interpretation of raw model activations difficult.
+
+## Monosemantic Features
+
+By contrast, the features extracted by sparse autoencoders are described as relatively **monosemantic**, meaning each feature tends to correspond to a single, coherent semantic concept rather than a mixture of unrelated ones.[10] This decomposition into more monosemantic units has been quantified using metrics such as the MonoSemanticity (MS) score, with empirical results showing that SAEs consistently improve monosemanticity compared to examining raw neurons directly.[28] The features produced in this way are also noted to be human-interpretable and to capture structure that is effectively invisible when inspecting neurons alone.[10]
+
+## Functional and Conceptual Representations
+
+Beyond detecting static concepts, research has shown that moving from fixed-dimensional to functional representations extends the capacity of sparse autoencoders from mere detectors of concept presence to richer characterizations of how concepts are encoded.[13] SAEs have been employed as an unsupervised approach for understanding internal representations across a range of model types and scales,[21] and studies using toy models — small ReLU networks trained on synthetic data with sparse input features — have helped illuminate how and when models develop these superposed, polysemantic representations in the first place.[11]
+
+## Interpretability Implications
+
+The ability of SAEs to reveal hidden mechanisms underlying neural networks has been described as both powerful and productive of striking empirical results.[17] By surfacing features that align with human-recognizable semantic categories, SAEs provide a practical lens through which researchers can audit, understand, and potentially intervene on the internal computations of large language models.[4]
+
+# Evaluation Methods
+
+Evaluating the effectiveness of sparse autoencoders (SAEs) in language model interpretability presents unique challenges, as researchers must assess both the quality of extracted features and the degree to which those features aid human understanding of model behavior[29][30].
+
+## Monosemanticity Scoring
+
+A central metric used in SAE evaluation is the **monosemanticity score (MS)**, which quantifies the extent to which individual neurons or latent units encode a single, coherent concept rather than multiple unrelated ones[28][5]. Polysemanticity—the phenomenon whereby individual neurons encode more than one concept simultaneously—is considered a primary obstacle to mechanistic interpretability[5][10]. SAEs are evaluated by comparing the monosemanticity of their decomposed features against baseline "No SAE" neuron activations, with higher MS scores indicating more interpretable, disentangled representations[28]. Experimental results have confirmed that SAEs trained on vision-language models (VLMs) such as CLIP significantly enhance monosemanticity at the level of individual neurons, with sparsity and wider latent spaces identified as key contributing factors[15].
+
+## Comparison with Linear Probes
+
+SAE performance is also benchmarked against **linear probes**, a standard supervised method for extracting information from neural network representations. Research through tools such as AXBENCH has revealed certain limitations of SAEs relative to linear probes for specific language model interpretation tasks, suggesting that SAEs, while powerful, do not universally outperform supervised approaches across all evaluation criteria[3].
+
+## Human Interpretability Assessments
+
+Beyond quantitative metrics, SAE features are evaluated through **human interpretability assessments**, in which annotators examine whether individual latent features correspond to recognizable, human-understandable concepts[29][22]. Studies have shown that SAEs produce features that are effectively invisible at the raw neuron level but become apparent upon decomposition, underscoring their utility for surfacing latent structure in model representations[10].
+
+## Applications in Specialized Domains
+
+Evaluation has also extended to **domain-specific settings**. In the medical field, for example, SAEs have been assessed for their ability to improve mechanistic interpretability of large language models (LLMs), with experimental designs measuring whether decomposed features align with clinically meaningful concepts[31]. Similarly, evaluations applied to VLMs examine whether SAE-derived features improve the interpretability of multimodal representations[14][15].
+
+## Unsupervised Benchmarking
+
+Because SAEs operate as an **unsupervised approach**, their evaluation must account for the absence of ground-truth feature labels[21][18]. Researchers assess reconstruction fidelity—how accurately the SAE can reconstruct original model activations from sparse codes—alongside feature sparsity and the human-judged coherence of discovered features, balancing these criteria to produce a holistic evaluation of SAE quality[30][18].
+
+# Key Findings and Results
+
+## Interpretability and Feature Discovery
+
+Research has consistently demonstrated that sparse autoencoders (SAEs) are capable of revealing hidden mechanisms underlying neural networks, producing striking and powerful results in the process[17]. Studies have shown that SAEs can effectively discover human-interpretable features in language models, decomposing the complex, superposed representations within large language models (LLMs) into features that correspond to distinct semantic concepts[22][4]. By training a sparse autoencoder to reconstruct the activations of a target network layer while enforcing sparsity constraints, SAEs expose structured internal representations that would otherwise remain opaque[19].
+
+## Sparsity and Scaling
+
+Sparsity is enforced during training to ensure the autoencoder learns high-level features by activating only a small subset of neurons, typically achieved through L1 regularization[7]. Systematic studies of scaling laws with respect to sparsity, autoencoder size, and language model size have provided guidance for more effective SAE training[12][24]. To address the challenge of scaling SAEs to many more features, novel architectures such as the Switch SAE have been introduced, leveraging conditional computation to do so efficiently[1].
+
+## Applications Beyond Text
+
+Beyond standard LLMs, SAEs have been applied to Vision-Language Models (VLMs) such as CLIP, where they enhance interpretability by decomposing multimodal representations into more understandable components[14]. SAEs have also been explored as a promising approach to improving mechanistic interpretability of LLMs in medical contexts, highlighting their potential for high-stakes domain applications[31].
+
+## Limitations and Comparisons
+
+Despite their promise, SAEs show certain limitations when compared to alternative methods such as linear probes for language model interpretation[3]. Research using toy models — small ReLU networks trained on synthetic data with sparse input features — has helped clarify how and when models form the kinds of representations that SAEs are best suited to detect[11]. More recent work has further extended SAEs from detectors of static concepts toward functional representations, broadening their interpretive scope[13]. Whether SAEs reliably and consistently discover interpretable features across diverse real-world language models, and how well their benefits scale, remains an active area of investigation[32][28].
+
+# Behavioral Intervention and Steering
+
+Beyond interpretability, sparse autoencoders offer practical mechanisms for directly influencing the behavior of language models.[29] Because SAEs decompose model activations into sets of sparsely activating, human-understandable features, these features can serve as intervention points to guide or alter model outputs.[9]
+One of the most direct applications involves activation steering, wherein specific SAE features are artificially activated or suppressed during inference to steer the model's generation in a desired direction.[10] For example, activating a feature associated with a particular concept—such as a base64 encoding pattern—can cause the model to generate content reflecting that concept, demonstrating that SAE features correspond to meaningful, causally relevant directions in the model's representation space.[10]
+This capacity for intervention is closely tied to the property of monosemanticity, the degree to which a single feature corresponds to a single, coherent concept.[9] Features identified by alternative approaches, such as raw neurons or principal components, tend to be polysemantic, encoding multiple unrelated concepts simultaneously, which makes targeted intervention less precise.[11] SAE features, by contrast, are more monosemantic and therefore more suitable as levers for controlled behavioral modification.[9]
+From a mechanistic interpretability standpoint, the ability to intervene on model behavior via SAE features provides a test of whether extracted features are not merely correlational but genuinely causal components of the underlying computation.[1] This aligns with the broader goal of mechanistic interpretability—to produce explanations that are correct, parsimonious, and faithful to actual model computations.[2]
+Scaling these intervention capabilities to larger and more expressive feature sets remains an active research challenge. Architectures such as the Switch SAE have been proposed to scale sparse autoencoders to many more features through conditional computation, potentially enabling finer-grained and more targeted behavioral steering.[1]
+
+# Limitations and Criticisms
+
+Despite their promise as a tool for mechanistic interpretability, sparse autoencoders (SAEs) face a number of significant limitations and criticisms that have been identified by researchers in the field.
+
+## Incomplete Disentanglement and Superposition
+
+While SAEs were designed to address the problem of superposition — whereby neural networks represent more features than they have dimensions by superimposing multiple concepts onto the same neurons — the disentanglement they achieve is not always complete or reliable[3]. The learned overcomplete sparse representations may still conflate distinct concepts, meaning that individual SAE features do not always correspond cleanly to human-interpretable units of meaning[11].
+
+## Performance Relative to Simpler Methods
+
+Research has indicated that SAEs show certain limitations compared to simpler, more direct approaches such as linear probes for language model interpretation[3]. This raises questions about whether the added complexity of training and deploying SAEs is justified in all interpretability contexts, particularly when more straightforward supervised methods may yield more reliable results with less computational overhead.
+
+## Scalability and Computational Cost
+
+Training SAEs on large language models demands substantial GPU memory and compute resources[23]. While scaling laws have been studied to guide SAE training[12][24], the resource requirements may limit accessibility and reproducibility, especially as model sizes continue to grow.
+
+## Fixed-Dimensional Representations
+
+Traditional SAE architectures rely on fixed-dimensional representations, which constrains their expressive capacity. This limitation has motivated research into functional representations that extend SAEs from mere detectors of concepts to more flexible tools[13], suggesting that current standard designs are not fully adequate for capturing the richness of learned model representations.
+
+## Scope Limited to Specific Modalities and Architectures
+
+Much of the foundational work on SAEs for interpretability has focused on specific model types, such as large language models or, more recently, vision-language models like CLIP[14]. The generalizability of findings across diverse architectures and modalities remains an open question[21].
+
+## Faithfulness and Parsimony Concerns
+
+A core goal of mechanistic interpretability is to produce explanations that are not only human-readable but also correct, parsimonious, and faithful to the underlying computations[2][1]. Critics argue that features extracted by SAEs do not always meet these standards, as it remains difficult to verify that the decomposed features genuinely reflect the model's internal reasoning rather than artifacts of the SAE training process[11].
+
+## Alternative Design Pressures
+
+The limitations of standard SAE architectures have spurred exploration of alternative designs, such as stochastic encoder networks with novel gating mechanisms[16], indicating that the field has not converged on a canonical, universally satisfactory approach. This ongoing design experimentation reflects the immaturity of SAEs as a fully validated interpretability method.
+
+# Variants and Extensions
+
+## Architectural Variants
+
+Researchers have explored several alternative sparse autoencoder (SAE) architectures to improve upon the standard design. One notable variant is the Switch SAE, which leverages conditional computation to efficiently scale SAEs to a significantly larger number of features, offering improved coverage of the representational space within large language models.[1] Another alternative design introduces a stochastic encoder network with a novel gating mechanism, which provides notable benefits over conventional approaches in terms of both feature quality and training dynamics.[16]
+
+## Functional and Higher-Dimensional Representations
+
+Beyond fixed-dimensional feature extraction, recent work has investigated moving from fixed-dimensional to functional representations. This extension broadens the role of SAEs from mere detectors of discrete concepts to richer tools capable of capturing more nuanced model behavior, demonstrating that functional representations can meaningfully extend the interpretability capabilities of standard sparse autoencoders.[13]
+
+## Scaling and Sparsity
+
+A growing body of research has examined the scaling properties of SAEs with respect to sparsity, autoencoder size, and the size of the underlying language model.[12] Empirical scaling laws have been established to guide the training of SAEs at different scales, showing that larger and more sparse autoencoders tend to yield more interpretable and monosemantic features.[9][24] The role of L1 regularization has been particularly emphasized, as sparsity induced by this penalty encourages the autoencoder to learn better, more disentangled representations with sparser activations overall.[8]
+
+## Monosemanticity and Feature Quality
+
+A key goal across SAE variants is the extraction of monosemantic features — directions in activation space that correspond reliably to a single, human-interpretable concept.[10] Both standard and novel SAE architectures have been evaluated on this criterion, with results showing that features learned through sparse training objectives are substantially more interpretable than those identified by alternative dimensionality reduction approaches.[9][21] The decomposition of complex, superposed representations within LLMs into distinct semantic concepts remains a central motivation driving the development of new SAE variants.[4]
+
+# Related Work
+
+The development of sparse autoencoders (SAEs) for language model interpretability sits at the intersection of several active research areas. The broader field of mechanistic interpretability seeks to open the black box of neural networks and rigorously explain the underlying computations[1], with the overarching goal of returning correct, parsimonious, and faithful explanations of neural network behavior[2].
+Early foundational work in mechanistic interpretability employed toy models — small ReLU networks trained on synthetic data with sparse input features — to investigate how and when models learn certain internal representations[11]. These studies laid the groundwork for understanding the phenomenon of superposition, whereby neural networks represent more features than they have dimensions, motivating the need for tools capable of disentangling such representations.
+SAEs address this challenge by learning an overcomplete, sparse representation of neural activations, effectively disentangling superimposed features into more interpretable components[3][18]. The features extracted through this process have been shown to be relatively monosemantic and interpretable, in contrast to directions identified by alternative approaches[10][9]. Notably, recent work has demonstrated that SAEs are able to effectively discover human-interpretable features in language models[22], establishing them as a practical tool for mechanistic analysis.
+Beyond language models, SAEs have been applied to Vision-Language Models (VLMs) such as CLIP, where they decompose internal representations to enhance interpretability across modalities[14]. Further extensions have explored moving from fixed-dimensional to functional representations, broadening sparse autoencoders from mere detectors of concepts to richer analytical tools[13]. The application of SAEs has also expanded into domain-specific settings, including medicine, where they have been explored as a promising approach to improving the mechanistic interpretability of large language models (LLMs)[31].
+
+# Research Groups and Notable Contributions
+
+## Toy Models and Mechanistic Interpretability
+
+Early foundational work in sparse autoencoder (SAE) interpretability drew significantly on studies using toy models — small ReLU networks trained on synthetic data with sparse input features — to investigate how and when neural networks represent information in superposition.[11] These simplified experimental setups allowed researchers to develop and test hypotheses about feature geometry and polysemanticity in a controlled environment before scaling findings to larger language models.
+
+## Sparse Autoencoders for Large Language Models
+
+Subsequent research expanded the application of SAEs as a means to improve the interpretability and steerability of Large Language Models (LLMs).[28] Groups working in this area have focused on training SAEs to decompose internal model activations into sparse, interpretable features, with the broader goal of making the internal representations of frontier models more transparent and amenable to human understanding.
+
+## Benchmarking and Comparative Evaluation
+
+More recent work has begun to systematically evaluate the strengths and limitations of SAEs relative to other interpretability methods. Benchmarking efforts such as AXBENCH have highlighted certain limitations of SAEs compared to linear probes for language model interpretation, suggesting that while SAEs offer advantages in unsupervised feature discovery, targeted linear probes can outperform them on specific tasks.[3] These comparative studies have been important in calibrating expectations for SAE-based methods and directing future research toward addressing their weaknesses.

--- a/src/content/research/autoresearcher.mdx
+++ b/src/content/research/autoresearcher.mdx
@@ -2,12 +2,90 @@
 title: "autoresearcher"
 date: 2026-05-24
 tags: []
-summary: "The Leaflet design: a group of agents that surveys a field, generates hypotheses (with poetry), runs experiments, writes papers — plus the readings that got us here."
+summary: "The Leaflet auto-researcher: design, framework with sample runs (STORM survey + Co-Scientist hypothesis generation on SAEs), and the readings that got us here."
 draft: false
 meta:
   is_finished: false
   opinion_strength: 7
   evidence_strength: 6
+---
+
+## autoresearcher design
+
+The Leaflet stack has three core steps. This section is the working framework — what each step actually does, the prompt sequence that drives it, and a real sample I ran on the SAE topic.
+
+### Step 1 — Survey (STORM)
+
+The survey step is Stanford's **STORM** (Synthesis of Topic Outlines through Retrieval and Multi-perspective Question Asking — [paper](https://arxiv.org/abs/2402.14207) / [code](https://github.com/stanford-oval/storm)).
+
+Given a topic string, STORM produces a Wikipedia-style article from scratch by:
+
+1. Generating writer personas (from related Wikipedia tables of contents).
+2. Simulating one multi-turn conversation per persona — each turn = ask a question, decompose into search queries, retrieve snippets, answer.
+3. Drafting an outline from parametric knowledge, then refining it using the conversations.
+4. Writing each section using the retrieved snippets, with citations.
+5. Adding a summary at the top and deduping.
+
+The exact LM-call-by-LM-call prompt sequence is here: **<a href="/research/autoresearcher/storm_prompt_sequence.html" target="_blank" rel="noopener">storm_prompt_sequence.html</a>** ← click through.
+
+#### Sample run on SAEs
+
+**Input:**
+
+```
+--topic "Sparse autoencoders in language model interpretability"
+--retriever serper
+--max-conv-turn 2 --max-perspective 2 --search-top-k 3
+```
+
+Run on Claude Code as the LM (custom dspy adapter shelling out to `claude -p`) + Serper for web retrieval. Wall-clock: ~7m45s. ~30 LM calls, 18 Serper queries.
+
+**Output:** a 36K-character Wikipedia-style article with citations to Anthropic Circuits Thread, OpenAI SAE paper, arxiv, OpenReview. Full article: **<a href="/research/autoresearcher/storm_sae_article.txt" target="_blank" rel="noopener">storm_sae_article.txt</a>**.
+
+Excerpt — the opening summary paragraph:
+
+> **Sparse autoencoders** (**SAEs**) are a class of neural network architectures that have emerged as a prominent tool in mechanistic interpretability, a subfield of artificial intelligence research that aims to open the black box of neural networks and rigorously explain the underlying computations they perform. Their primary application is the decomposition of the complex, superposed internal representations of large language models (LLMs) into components that correspond to distinct, human-interpretable semantic concepts. […]
+
+*Honest gaps for Leaflet:* STORM produces a clean article but doesn't fully match what Leaflet step 1 wants — no explicit history/timeline section, people aren't named (Olah, Cunningham, Bricken, Templeton, Nanda), datasets/open-source assets aren't enumerated, and the outline is parametric-knowledge-driven rather than literature-driven. Natural upgrades for the Leaflet variant: academic-only retriever (Semantic Scholar / paper-qa), explicit history + people + datasets sub-prompts, and a citation-precision verification pass.
+
+### Step 2 — Hypothesis generation (Co-Scientist)
+
+The hypothesis-generation step is an open-source re-implementation of Google's **AI co-scientist** ([Gottweis et al., *Nature*, 2026](https://www.nature.com/articles/s41586-026-10644-y) / [Google research blog](https://research.google/blog/accelerating-scientific-breakthroughs-with-an-ai-co-scientist/)). The agent roster, prompts, and control flow follow the paper.
+
+The agents:
+
+- **Generation** — proposes hypotheses via literature review and simulated scientific debate.
+- **Reflection** — reviews hypotheses for novelty, correctness, and testability; deep-verifies the underlying assumptions.
+- **Ranking** — runs an Elo tournament with simulated debates between hypotheses.
+- **Evolution** — combines, simplifies, makes more feasible, or out-of-box-reimagines top-ranked hypotheses.
+- **Proximity** — embeds and clusters hypotheses to drive dedup and informative tournament pairings.
+- **Meta-review** — synthesizes system-wide feedback and the final research overview.
+
+A **Supervisor** parses the goal into a research plan and schedules agent tasks through a durable SQLite-backed queue.
+
+The exact LM-call-by-LM-call prompt sequence is here: **<a href="/research/autoresearcher/co_scientist_prompt_sequence.html" target="_blank" rel="noopener">co_scientist_prompt_sequence.html</a>** ← click through.
+
+#### Sample run on SAEs
+
+**Input:**
+
+```
+co-scientist run "test SAEs as way to interpret neural networks" \
+  --n 3 --budget-usd 2.0 --wall-clock 900
+```
+
+**Output:** the Meta-review agent's final research overview. Top-ranked hypothesis was *SAE feature-splitting as a causal concept hierarchy* — test whether features that appear at smaller dictionary sizes have greater causal effect on downstream task performance than features only appearing at larger sizes. Full overview: **<a href="/research/autoresearcher/co_scientist_sae_overview.md" target="_blank" rel="noopener">co_scientist_sae_overview.md</a>**.
+
+Excerpt — the executive summary:
+
+> The tournament converged on a single top-ranked hypothesis exploring how Sparse Autoencoder (SAE) feature-splitting hierarchies might encode causal structure within neural networks. The core idea — that features learned at smaller dictionary sizes are causally more central than those appearing only at larger sizes — is a compelling operationalization of mechanistic interpretability that bridges representation learning and causal inference. […] Acting on it could yield a principled, falsifiable framework for evaluating whether SAEs do more than describe activations — whether they actually illuminate *how* models compute.
+
+Concrete first experiment proposed: train SAEs at 3–5 dictionary sizes (512 / 2048 / 8192 / 32768 features) on a single residual-stream layer of a small open-weight LLM (Pythia-1.4B or GPT-2-XL); compute activation-patching effect sizes per feature on 2–3 downstream tasks; test whether mean effect size is significantly higher for features in the smallest SAE vs. the largest. 4–8 weeks of work with standard interpretability tooling (TransformerLens, SAELens).
+
+### Step 3 — Experimentation and writeup
+
+Detailed setup pending — this step uses Sakana's AI Scientist v2 (cloned at `~/AI-Scientist-v2/`), with ShinkaEvolve inside it where evolutionary search beats greedy iteration, and AlphaEvolve as the design reference. The hypothesis from step 2 is the input. The output is a paper + code that ran.
+
 ---
 
 ## specifics


### PR DESCRIPTION
## Summary

New top section on `/research/autoresearcher/` titled **autoresearcher design**, sitting above the existing `specifics` and `plan sketching readings` sections.

### What it contains

**Step 1 — Survey (STORM)**
- How it works (5-stage pipeline from the stanford-storm README)
- Linked: [storm_prompt_sequence.html](/research/autoresearcher/storm_prompt_sequence.html) — exact LM-call-by-LM-call prompt sequence
- Sample run on `"Sparse autoencoders in language model interpretability"` — claude-code adapter + Serper, ~7m45s, ~30 LM calls
- Output: [storm_sae_article.txt](/research/autoresearcher/storm_sae_article.txt) — 36K-character Wikipedia-style article with citations
- Honest gaps for Leaflet flagged

**Step 2 — Hypothesis generation (Co-Scientist)**
- 6-agent roster (Generation / Reflection / Ranking / Evolution / Proximity / Meta-review) + Supervisor
- Linked: [co_scientist_prompt_sequence.html](/research/autoresearcher/co_scientist_prompt_sequence.html) — full prompt sequence
- Sample run on `"test SAEs as way to interpret neural networks"` — `--n 3 --budget-usd 2.0 --wall-clock 900`
- Output: [co_scientist_sae_overview.md](/research/autoresearcher/co_scientist_sae_overview.md) — top hypothesis: SAE feature-splitting as a causal concept hierarchy, with concrete 4–8 week first experiment

**Step 3 — Experimentation and writeup**
- Placeholder pointing at AI Scientist v2 + ShinkaEvolve + AlphaEvolve. Will fill in once step 3 is actually running.

### Static assets

Copied to `public/research/autoresearcher/`:
- `storm_prompt_sequence.html` (8K)
- `co_scientist_prompt_sequence.html` (16K)
- `storm_sae_article.txt` (the polished article)
- `co_scientist_sae_overview.md` (the Meta-review final overview)

### Test plan
- [x] `npm run build` succeeds (28 pages)
- [x] All 4 static assets emitted to `dist/research/autoresearcher/`
- [ ] Verify on deployed preview: prompt-sequence HTMLs open inline, sample articles download/render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)