### PR TITLE
fantasy: add 'how much carbon do we have left' stub page

### DIFF
--- a/src/content/fantasy/how-much-carbon-do-we-have-left.mdx
+++ b/src/content/fantasy/how-much-carbon-do-we-have-left.mdx
@@ -1,0 +1,13 @@
+---
+title: "how much carbon do we have left"
+date: 2026-06-02
+tags: []
+summary: "Stub — to be filled in."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 5
+  evidence_strength: 5
+---
+
+*Page placeholder — content coming.*

--- a/src/content/fantasy/how-much-carbon-do-we-have-left.mdx
+++ b/src/content/fantasy/how-much-carbon-do-we-have-left.mdx
@@ -11,3 +11,5 @@ meta:
 ---
 
 *Page placeholder — content coming.*
+
+<iframe width="100%" height="400" style="max-width: 720px; display: block; margin: 1.5rem auto; aspect-ratio: 16/9;" src="https://www.youtube.com/embed/pXVmkurTOgM" title="how much carbon do we have left" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -30,6 +30,7 @@ export const site = {
     'research/complex-systems',
     'data/areas-of-ai',
     'fantasy/me-and-moon',
+    'fantasy/how-much-carbon-do-we-have-left',
   ] as string[],
 
   // External subscribe URL (homepage button).


### PR DESCRIPTION
## Summary
Stub page at `/fantasy/how-much-carbon-do-we-have-left/`. Placeholder body — content coming from janhavi. Flagged as unfinished in `site.config.ts` so the "this writing isn't finished yet" bar shows at the top.

## Test plan
- [x] `npm run build` succeeds (29 pages, was 28)
- [x] Route emitted: `dist/fantasy/how-much-carbon-do-we-have-left/index.html`
- [ ] Verify preview renders the unfinished bar
- [ ] janhavi adds content

🤖 Generated with [Claude Code](https://claude.com/claude-code)