### PR TITLE
fantasy: add 'Pilot' — opening of the Ethal story

### DIFF
--- a/src/content/fantasy/pilot.mdx
+++ b/src/content/fantasy/pilot.mdx
@@ -85,3 +85,10 @@ Those aliens. They ocnsider them selves so advanced. My science failed. It can't
 He was loosing it.
 
 So he decides he needed a change of place., and booked a seat in upcoming space shiip to mars. He thought may be it will clear his mind and he would be ready to give one more shot to solving M31. He had few months before the end.
+
+---
+
+## References
+
+- [Brandon Sanderson — Shattered Plains (Coppermind wiki)](https://coppermind.net/wiki/Shattered_Plains)
+- [Sky Pride — Royal Road](https://www.royalroad.com/fiction/107917/sky-pride)

--- a/src/content/fantasy/pilot.mdx
+++ b/src/content/fantasy/pilot.mdx
@@ -1,0 +1,67 @@
+---
+title: "Pilot"
+date: 2026-06-02
+tags: []
+summary: "Ethal, high scientist of the MatterLand, packs for Mars three days before a galaxy-collapsing explosion — and finds his science failing him."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 8
+  evidence_strength: 1
+---
+
+# Pilot
+
+---
+
+> He was famous for his quote, *"Human is a speceice if left naked in sahara, will brute force their way to the atom bomb."*
+>
+> — Ethal
+
+---
+
+Ethal, holding the book and reading this,
+
+> When Etha created mud,
+> Mud created Adam,
+> Adam developed greed,
+> greed created Racazar.
+>
+> Raca asked Etha, Oh Etha, why shall you let me live if you were to pain me everyday
+> Raca asked for happiness.
+>
+> Etha thus, granted him happiness.
+
+*[this needs better ending. some tension release, some reason behind why etha granted him happiness, get the angle of one brahma year is this many raca year, one raca year is this many human year]*
+
+---
+
+Ethal was named Etha, after the almighty god by his parents. He later changed it to Ethal. He wanted something personal.
+
+Ethal was packing for his departure to mars. He was to take the space ship in 3 days. He had decided this after some thinking. He was stuck. He was in conflict.
+
+His whole life's beliefs were falling apart in front of his eyes. He always considered himself the responsible to keep the shit together, he tried but this time, there seem to be no way out.
+
+Ethal was one of the high scientists of the MatterLand. He had spent his entire life from he was a little boy till today doing science. He was bullish on humanity, and our capabilities. He was certain that we humans invented science, and science is the answer to all the questions. His life was dedicated to fidning answers to question of universe, question of time, question of free will. He alwasy found answers.
+
+Humanity owns him for discovering time laws, space laws, supernova research, complexity science, autopoiotic processes. nothing was out of reach of science if you were to ask Ethal.
+
+So he broke when his beliefs failed. His specie was in danger from the nearby super galactic changes. M31 was exploding. And in few months, if they don't find the solution they would be wiped out by the blast. Astornomers swere observing M31 since years. In fact, this was one of the galaxies for which we had tons of data. In past , Ethal and his teams has made countless predictions about its motion, its behaviour and its quirks which were later observed to be true by telescopes. M31 was our very dearest neightbour.
+
+How could they not see the explosion coming. What was missing? We had solved most of the space and cosmos and its behaviour. This can not be happening. Where has his science failed.
+
+Had radio signals from the mindLand not reached their SETI, they would never even have known till last few weeks. On June 3, their SETI telescopes started receiving ocntinuous sharp signals from the start right north. After weeks of it, it became very clear to every high sciene team in humanity that we have finally made thefirst contact.
+
+they were trying to communicate. Intentionally. There was a fear, excitement too. There had only been communication, nothing else. To everyone's surprice, they had sent signals in the language we would understand.
+
+It took weeks to set that in their minds. But after a week we were done decifering their signals.
+
+They were warning us. They were sending us help. The message was sharp clear.
+
+> *"M31 is exploding. We are offering you the solution to escape. Prepare to receive us, extend your hand."*
+
+What.
+
+this was quickly send across all high science teams in humanity, including Ethal's team. Ethal recollects the moment he got the news. He was having his coffee, he gets the mesage from his team memeber, he calls everyone in the living room and goes, *"we have gotten an email form the government. The message from alien specie, 'M31 is exploding. We are offering you the solution to escape. Prepare to receive us, extend your hand.'"*
+
+He repeated and email. He forwarded the email to everyone. Everyone checked again. They didn't know waht this feeling was. They had never experienced anything like this.

--- a/src/content/fantasy/pilot.mdx
+++ b/src/content/fantasy/pilot.mdx
@@ -65,3 +65,23 @@ What.
 this was quickly send across all high science teams in humanity, including Ethal's team. Ethal recollects the moment he got the news. He was having his coffee, he gets the mesage from his team memeber, he calls everyone in the living room and goes, *"we have gotten an email form the government. The message from alien specie, 'M31 is exploding. We are offering you the solution to escape. Prepare to receive us, extend your hand.'"*
 
 He repeated and email. He forwarded the email to everyone. Everyone checked again. They didn't know waht this feeling was. They had never experienced anything like this.
+
+What. aliens. no no, M31. It is exploding? can't be, I just checked its data. In fact I had been on it since months, it looks normal. It an't be.
+
+After much talks of days, they wrote back to government, their reports stll shows m31 behaving normally. No explosion expected. so their chief inputs wsa that this could be deception. why woudl they say something like this? what is their motive? how did they know our langugae, and how to communicate with us? Do we have osme of them living among us?
+
+government was receiving similar erplies from high science teams.
+
+Fast forward from that day to daoy, all high science teams has been slowly seeing the unpredicatable change in M31. If not exploding, it was for sure behaving differently. We were just observing at this point.
+
+Everytime, humanity was in danger, pendemic, wars, climate chagne, Ethal and his team were the ones to prepare the solution. They had to decide. They were alwasy the responsible ones to decide and course of next action. But this time, they were at the mercy of aliens. They tried.
+
+The rest of the world was feeling scared, fearing for their life. Praying to the safety. Some were preparing to say good by to the only home they had known. In few months this entire solar system was going to get wiped out.
+
+But Ethal had osmethign else going on in his mind. He was put along with the rest of the humans. He was not the one making decision this time.
+
+Those aliens. They ocnsider them selves so advanced. My science failed. It can't be. Egoistic basters. Saving us. Us. really. do think we own them. We are perfectly capable to find way out. What is ti. He doesn't know. His science is helpless. The alines seem to know everything. They seem to be knowing what is happening to M31. Ethal was to aliens like iliterate humans to Ethal. That is somehting Ethal hated. He was smart. His self worth dependen onthis.
+
+He was loosing it.
+
+So he decides he needed a change of place., and booked a seat in upcoming space shiip to mars. He thought may be it will clear his mind and he would be ready to give one more shot to solving M31. He had few months before the end.

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -30,6 +30,7 @@ export const site = {
     'research/complex-systems',
     'data/areas-of-ai',
     'fantasy/me-and-moon',
+    'fantasy/pilot',
   ] as string[],
 
   // External subscribe URL (homepage button).


### PR DESCRIPTION
## Summary

New fantasy page at `/fantasy/pilot/`. Opening of a story: Ethal, high scientist of the MatterLand, packs for Mars three days before M31's explosion would wipe out humanity. Alien signal from mindLand offers a way out.

Structure:
- Epigraph: Ethal's famous quote about humans and the atom bomb
- Etha / Adam / Racazar passage (the in-story scripture Ethal is reading)
- The story proper — Ethal's backstory + the M31 crisis + the alien message

Prose preserved **verbatim** including typos and the bracketed editor's note `[this needs better ending. some tension release...]` — kept visible so you don't lose the reminder. Page flagged as unfinished.

## Test plan
- [x] `npm run build` succeeds (29 pages)
- [x] Route emitted: `dist/fantasy/pilot/index.html`
- [ ] janhavi: revise the bracketed note + typos when ready; push continuation onto same branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)