### PR TITLE
Add novel wiki link to fantasy index

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,6 +24,7 @@ Most posts on this site are works-in-progress and explicitly flagged with a "thi
 ## Fantasy
 
 - [how to send a small satellite to the moon and take photos](https://concavemirror.to/fantasy/me-and-moon/): A practical guide to lunar CubeSat missions — mission design, propulsion, launch, trajectory, orbit insertion, imaging, link budgets.
+- [novel](https://novel.concavemirror.to/): The wiki of the epic fantasy novel — characters, places, threads. Separate Quartz site on a subdomain.
 
 ## Other
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -21,7 +21,14 @@ const postSchema = z.object({
 const blog = defineCollection({ type: 'content', schema: postSchema });
 const research = defineCollection({ type: 'content', schema: postSchema });
 const data = defineCollection({ type: 'content', schema: postSchema });
-const fantasy = defineCollection({ type: 'content', schema: postSchema });
+
+// Fantasy diverges: entries may be pure external links (e.g. the novel wiki
+// at novel.concavemirror.to). Link entries appear on the index but build no
+// internal page.
+const fantasy = defineCollection({
+  type: 'content',
+  schema: postSchema.extend({ link: z.string().url().optional() }),
+});
 
 // Tools have their own schema: plain-text + images, no opinion/evidence meta,
 // optional external "visit" link, and a category label.

--- a/src/content/fantasy/novel.md
+++ b/src/content/fantasy/novel.md
@@ -1,0 +1,13 @@
+---
+title: novel
+date: 2026-06-13
+link: https://novel.concavemirror.to/
+summary: the wiki of the epic fantasy novel — characters, places, threads.
+meta:
+  is_finished: false
+  opinion_strength: 0
+  evidence_strength: 0
+---
+
+External link entry — points to the novel wiki at novel.concavemirror.to.
+No page is built for this entry; the index links straight out.

--- a/src/pages/fantasy/[slug].astro
+++ b/src/pages/fantasy/[slug].astro
@@ -4,7 +4,7 @@ import { postComponents } from '@/lib/postComponents';
 import { getCollection, type CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('fantasy');
+  const posts = await getCollection('fantasy', ({ data }) => !data.link);
   return posts.map((post) => ({
     params: { slug: post.slug },
     props: { post },

--- a/src/pages/fantasy/index.astro
+++ b/src/pages/fantasy/index.astro
@@ -7,7 +7,7 @@ const posts = await getPublishedEntries('fantasy');
 const groups = groupIntoClusters('fantasy', posts).map((g) => ({
   id: g.id,
   posts: g.posts.map((p) => ({
-    href: `/fantasy/${p.slug}/`,
+    href: p.data.link ?? `/fantasy/${p.slug}/`,
     title: p.data.title,
   })),
 }));


### PR DESCRIPTION
Fantasy entries can now be pure external links via an optional link field (fantasy schema forked from postSchema per convention). The new "novel" entry points to the Quartz wiki at novel.concavemirror.to and builds no internal page.