### PR TITLE
fantasy/my-process: add stage 2; blog: add design-of-my-surroundings stub

### DIFF
--- a/src/content/blog/design-of-my-surroundings.mdx
+++ b/src/content/blog/design-of-my-surroundings.mdx
@@ -1,0 +1,13 @@
+---
+title: "design of my surroundings"
+date: 2026-06-03
+tags: []
+summary: "Stub — to be filled in."
+draft: false
+meta:
+  is_finished: false
+  opinion_strength: 5
+  evidence_strength: 5
+---
+
+*Page placeholder — content coming.*

--- a/src/content/fantasy/my-process-of-writing-long-novel.md
+++ b/src/content/fantasy/my-process-of-writing-long-novel.md
@@ -10,8 +10,6 @@ meta:
   evidence_strength: 3
 ---
 
-discovery writer.
-
 I start with the idea or opinion that interests me. For example, godel's theorem. And then imagine a story to best illustrate it and understand it better.
 
 this gets linked with bunch of smaller ideas and their plots and becomes a cluster.
@@ -19,3 +17,7 @@ this gets linked with bunch of smaller ideas and their plots and becomes a clust
 i have a mindland and matterland formed, and also godels' theorem that is going to create a plot that they two together are not consistant (which they had been looking for) but that is exectly hy they are complete. They can together add meaning.
 
 and I add sotry elements like grey people that links these two lands. 80% of the story is still empty, ideas will come to me naturally. I do not force. they never come that way.
+
+## stage 2
+
+I have recently found a second way of getting good ideas. I have more than 16 diaries, my own thoughts from age 10. I am rereading them and adding newer characters and arcs based on what I find in my diaries. It's like during this class I was going through this particular phase, I have notes of how I felt what I wanted to do, to which I do not relate at all at present, but I felt that once. Helps creating characters who don't feel like I feel right now.

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -31,6 +31,7 @@ export const site = {
     'data/areas-of-ai',
     'fantasy/me-and-moon',
     'fantasy/pilot',
+    'blog/design-of-my-surroundings',
   ] as string[],
 
   // External subscribe URL (homepage button).


### PR DESCRIPTION
## Summary

**fantasy/my-process-of-writing-long-novel:**
- removed the opening "discovery writer." line
- appended a `## stage 2` section verbatim from janhavi: re-reading her 16 diaries from age 10 onward to seed characters who don't feel like she feels right now

**blog/design-of-my-surroundings:**
- new stub page at `/blog/design-of-my-surroundings/` with placeholder body
- flagged as unfinished in `site.config.ts`

## Test plan
- [x] `npm run build` succeeds (30 pages, was 29)
- [x] Both routes emitted
- [ ] janhavi adds content to design-of-my-surroundings when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)