### PR TITLE
blog/leaflet: add co-author shubham gupta, add co_author schema field

### DIFF
--- a/src/content/blog/leaflet-my-autoresearcher.mdx
+++ b/src/content/blog/leaflet-my-autoresearcher.mdx
@@ -15,6 +15,9 @@ side_images:
   - /images/blog/leaflet-my-autoresearcher/sources/photo_986.jpg
   - /images/blog/leaflet-my-autoresearcher/sources/photo_987.jpg
   - /images/blog/leaflet-my-autoresearcher/sources/photo_988.jpg
+co_author:
+  name: shubham gupta
+  url: https://x.com/unlikefraction
 draft: false
 meta:
   is_finished: false

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -14,6 +14,7 @@ const postSchema = z.object({
   // at ~30% viewport width on the post page. Experimental — first used on
   // /blog/leaflet-my-autoresearcher/ as an alternative to a bg collage.
   side_images: z.array(z.string()).optional(),
+  co_author: z.object({ name: z.string(), url: z.string().url().optional() }).optional(),
   draft: z.boolean().default(false),
   meta: z.object({
     is_finished: z.boolean(),

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -12,6 +12,7 @@ interface Props {
   tags?: readonly string[];
   summary?: string;
   side_images?: string[];
+  co_author?: { name: string; url?: string };
   meta: {
     is_finished: boolean;
     opinion_strength: number;
@@ -22,7 +23,7 @@ interface Props {
 // `tags` and `meta` are accepted in the props (schema requires them) but not
 // rendered on the post page right now — the meta block was removed per janhavi
 // (2026-05-24); keeping the fields in frontmatter so the area can be restored.
-const { slug, title, summary, side_images } = Astro.props;
+const { slug, title, summary, side_images, co_author } = Astro.props;
 
 const isUnfinished = site.unfinished_slugs.includes(slug);
 
@@ -41,7 +42,16 @@ const rightMargin = 50 + Math.floor(Math.random() * 100) + 1;
     {isUnfinished && <UnfinishedBar />}
     <header class="post-header">
       <h1 class="post-title">{title}</h1>
-      <div class="post-meta-wrap"></div>
+      <div class="post-meta-wrap">
+        {co_author && (
+          <p class="co-author">
+            with{' '}
+            {co_author.url
+              ? <a href={co_author.url} target="_blank" rel="noopener noreferrer">{co_author.name}</a>
+              : co_author.name}
+          </p>
+        )}
+      </div>
     </header>
 
     <div class="post-body">
@@ -119,6 +129,18 @@ const rightMargin = 50 + Math.floor(Math.random() * 100) + 1;
     padding-bottom: var(--space-2);
     display: flex;
     align-items: flex-end;           /* keep meta content visually at bottom */
+  }
+
+  .co-author {
+    margin: 0;
+    font-size: 0.85rem;
+    font-family: var(--font-grotezk);
+    opacity: 0.7;
+  }
+  .co-author a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
 
   .post-body {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -25,6 +25,7 @@ const { Content } = await post.render();
   tags={post.data.tags}
   summary={post.data.summary}
   side_images={post.data.side_images}
+  co_author={post.data.co_author}
   meta={post.data.meta}
 >
   <Content components={postComponents} />


### PR DESCRIPTION
Renders "with <name>" in the post header meta area, linked to the author's URL. Adds optional co_author field to postSchema and PostLayout.